### PR TITLE
Add dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,28 @@ This project automates login and product ordering for the BGF Retail store site 
 
 ## Credentials
 
-Set the following environment variables before running any script:
+The scripts read credentials from environment variables. You can either export
+them or place them in a `.env` file.
+
+Set the following variables before running any script:
 
 - `BGF_USER_ID` – your login ID
 - `BGF_USER_PW` – your login password
 
-Example on Linux/macOS:
+Example on Linux/macOS using exports:
 
 ```bash
 export BGF_USER_ID=your_id
 export BGF_USER_PW=your_password
 python bgf_order_automation.py
 ```
+
+Or create a `.env` file in the project directory:
+
+```
+BGF_USER_ID=your_id
+BGF_USER_PW=your_password
+```
+
+The scripts use [python-dotenv](https://pypi.org/project/python-dotenv/) to
+load variables from this file automatically.

--- a/bgf_order_automation.py
+++ b/bgf_order_automation.py
@@ -4,7 +4,10 @@ import csv
 import logging
 import os
 import sys
+from dotenv import load_dotenv
 from playwright.async_api import async_playwright, TimeoutError as PlaywrightTimeoutError, Page, Locator
+
+load_dotenv()
 
 # ===============================================================================
 # 1. 초기 설정 및 상수 정의

--- a/bgf_order_automation_revised.py
+++ b/bgf_order_automation_revised.py
@@ -1,7 +1,10 @@
 import logging
 import os
 import sys
+from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright, TimeoutError
+
+load_dotenv()
 
 # --- 로깅 설정 ---
 console_handler = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file using `python-dotenv`
- document `.env` usage in README

## Testing
- `python -m py_compile bgf_order_automation.py bgf_order_automation_revised.py`

------
https://chatgpt.com/codex/tasks/task_e_684fb76630a483209d15011bccfa259c