### PR TITLE
Replace OCR with Selenium product scraper

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,7 @@ def launch_chrome_fullscreen(url: str) -> None:
         CHROME_PATH,
         f"--user-data-dir={USER_DATA_DIR}",
         f"--profile-directory={PROFILE_NAME}",
+        "--remote-debugging-port=9222",
         "--new-window",
         "--kiosk",
         url,


### PR DESCRIPTION
## Summary
- use Selenium to gather product names directly from the DOM
- drop full screen OCR routine
- enable remote debugging in Chrome launcher for Selenium connection

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68578df77f3c8320833405d09ff17298