### PR TITLE
Add JSON-based login automation

### DIFF
--- a/page_structure.json
+++ b/page_structure.json
@@ -1,0 +1,5 @@
+{
+  "id": "mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_id:input",
+  "password": "mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_pw:input",
+  "login_button": "btn_login:icontext"
+}


### PR DESCRIPTION
## Summary
- implement JSON config driven Selenium login
- keep browser open for inspection
- provide sample `page_structure.json` with target IDs

## Testing
- `python -m py_compile main.py order_navigation.py text_clicker.py ocr_utils.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68579a27053c8320b2239c9176c964bb