### PR TITLE
Handle missing page structure

### DIFF
--- a/auto_login_and_parse_icontext.py
+++ b/auto_login_and_parse_icontext.py
@@ -1,0 +1,25 @@
+import json
+from bs4 import BeautifulSoup
+
+INPUT_HTML = "sample_login_page.html"
+OUTPUT_JSON = "page_structure.json"
+
+def parse_structure(html_path: str = INPUT_HTML) -> None:
+    with open(html_path, "r", encoding="utf-8") as f:
+        soup = BeautifulSoup(f, "html.parser")
+
+    id_input = soup.find("input", {"type": "text"})
+    pw_input = soup.find("input", {"type": "password"})
+    login_btn = soup.find("button")
+
+    structure = {
+        "id": id_input.get("id") if id_input else "",
+        "password": pw_input.get("id") if pw_input else "",
+        "login_button": login_btn.get("id") if login_btn else "",
+    }
+
+    with open(OUTPUT_JSON, "w", encoding="utf-8") as f:
+        json.dump(structure, f, ensure_ascii=False, indent=2)
+
+if __name__ == "__main__":
+    parse_structure()


### PR DESCRIPTION
## Summary
- add automatic page structure parser `auto_login_and_parse_icontext.py`
- improve `main.py` to load `page_structure.json` safely and generate it if missing

## Testing
- `python -m py_compile main.py build_structure.py auto_login_and_parse_icontext.py order_navigation.py text_clicker.py utils.py ocr_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68579d4983688320a1ebbdd3d87289ea