### PR TITLE
Check user_id before filling login

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,6 +59,8 @@ def main() -> None:
         login_keyword = structure["login_button"]
 
         # ③ 로그인 진행
+        if not user_id:
+            raise ValueError("user_id가 설정되지 않았습니다.")
         page.fill(f"#{id_field}", user_id)
         page.fill(f"#{pw_field}", user_pw)
         page.click(f"#{login_keyword}")


### PR DESCRIPTION
## Summary
- raise `ValueError` if `user_id` is missing before attempting to fill the login field

## Testing
- `pytest -q`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6857a11800f48320a7b847d541ff27d2