### PR TITLE
Fix login selectors

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,9 +61,9 @@ def main() -> None:
         # ③ 로그인 진행
         if not user_id:
             raise ValueError("user_id가 설정되지 않았습니다.")
-        page.fill(f"#{id_field}", user_id)
-        page.fill(f"#{pw_field}", user_pw)
-        page.click(f"#{login_keyword}")
+        page.fill(id_field, user_id)
+        page.fill(pw_field, user_pw)
+        page.click(login_keyword)
 
         # ④ 로그인 후 나타나는 팝업 닫기
         try:


### PR DESCRIPTION
## Summary
- use selectors directly from `page_structure.json` instead of prepending `#`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6857abe258f08320ba11c1ea887e40f8