### PR TITLE
Refactor login flow with runtime configuration

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -1,0 +1,48 @@
+import json
+import os
+from playwright.sync_api import sync_playwright
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_config() -> dict:
+    with open(os.path.join(BASE_DIR, "runtime_config.json"), "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_structure() -> dict:
+    with open(os.path.join(BASE_DIR, "page_structure.json"), "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def run() -> None:
+    """Run login automation with popup handling."""
+    cfg = load_config()
+    st = load_structure()
+    url = "https://store.bgfretail.com/websrc/deploy/index.html"
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        page = browser.new_page()
+        page.goto(url)
+
+        page.locator(st["id"]).click()
+        page.keyboard.type(cfg["user_id"])
+        page.locator(st["password"]).click()
+        page.keyboard.type(cfg["user_pw"])
+        page.locator(st["login_button"]).click()
+
+        wait_after_login = cfg.get("wait_after_login", 0)
+        if wait_after_login:
+            page.wait_for_timeout(wait_after_login * 1000)
+
+        for sel in cfg.get("popup_selectors", []):
+            if page.locator(sel).count() > 0:
+                page.locator(sel).click()
+                break
+
+        browser.close()
+
+
+if __name__ == "__main__":
+    run()

--- a/page_structure.json
+++ b/page_structure.json
@@ -1,5 +1,5 @@
 {
-  "id": "login_id",
-  "password": "login_pw",
-  "login_button": "btn_login"
+  "id": "[id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_id\\:input']",
+  "password": "[id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.edt_pw\\:input']",
+  "login_button": "[id='mainframe.HFrameSet00.LoginFrame.form.div_login.form.btn_login']"
 }

--- a/runtime_config.json
+++ b/runtime_config.json
@@ -1,0 +1,6 @@
+{
+  "user_id": "your_id_here",
+  "user_pw": "your_password_here",
+  "wait_after_login": 2,
+  "popup_selectors": ["#popupClose", "img[src*='popup_close']", "[class*='close']"]
+}


### PR DESCRIPTION
## Summary
- support runtime configuration for login credentials and popup selectors
- replace `.fill()` usage with `.click()` + `keyboard.type()` input
- add new Codex runner script for streamlined login
- include sample selectors in page structure

## Testing
- `python -m py_compile main.py codex_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_6857f1a45ad08320a93991cae86b45ec