### PR TITLE
Load login credentials from .env

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -1,6 +1,10 @@
 import json
 import os
 from playwright.sync_api import sync_playwright
+from dotenv import load_dotenv
+
+# Load environment variables from .env
+load_dotenv()
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -19,7 +23,15 @@ def run() -> None:
     """Run login automation with popup handling."""
     cfg = load_config()
     st = load_structure()
+
+    # ID/PW from environment variables
+    user_id = os.getenv("LOGIN_ID")
+    user_pw = os.getenv("LOGIN_PW")
     url = "https://store.bgfretail.com/websrc/deploy/index.html"
+
+    if not user_id or not user_pw:
+        print("LOGIN_ID 또는 LOGIN_PW가 설정되지 않았습니다.")
+        return
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
@@ -27,10 +39,17 @@ def run() -> None:
         page.goto(url)
 
         page.locator(st["id"]).click()
-        page.keyboard.type(cfg["user_id"])
+        page.keyboard.type(user_id)
         page.locator(st["password"]).click()
-        page.keyboard.type(cfg["user_pw"])
+        page.keyboard.type(user_pw)
         page.locator(st["login_button"]).click()
+
+        try:
+            close_btn = page.locator("[class*='close']")
+            if close_btn.count() > 0:
+                close_btn.click()
+        except Exception as e:
+            print(f"경고창 닫기 실패: {e}")
 
         wait_after_login = cfg.get("wait_after_login", 0)
         if wait_after_login:


### PR DESCRIPTION
## Summary
- support `.env` login credentials in `main.py` and `codex_runner.py`
- attempt to close login failure popup `[class*='close']`

## Testing
- `python -m py_compile main.py codex_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68587aad8f148320a2b35315cc7f8db3