### PR TITLE
Refine popup close selector

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -44,12 +44,6 @@ def run() -> None:
         page.keyboard.type(user_pw)
         page.locator(st["login_button"]).click()
 
-        try:
-            close_btn = page.locator("[class*='close']")
-            if close_btn.count() > 0:
-                close_btn.click()
-        except Exception as e:
-            print(f"경고창 닫기 실패: {e}")
 
         wait_after_login = cfg.get("wait_after_login", 0)
         if wait_after_login:

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def main() -> None:
     wait_after_login = runtime_config.get("wait_after_login", 0)
     popup_selectors = runtime_config.get(
         "popup_selectors",
-        ["#popupClose", "img[src*='popup_close']", "[class*='close']"],
+        ["#popupClose", "img[src*='popup_close']"],
     )
 
     structure_file = os.path.join(BASE_DIR, "page_structure.json")
@@ -82,13 +82,6 @@ def main() -> None:
         page.keyboard.type(user_pw)
         page.locator(login_keyword).click()
 
-        # 로그인 실패 경고창이 존재하면 닫기 시도
-        try:
-            close_btn = page.locator("[class*='close']")
-            if close_btn.count() > 0:
-                close_btn.click()
-        except Exception as e:
-            print(f"경고창 닫기 실패: {e}")
 
         if wait_after_login:
             page.wait_for_timeout(wait_after_login * 1000)

--- a/runtime_config.json
+++ b/runtime_config.json
@@ -2,5 +2,5 @@
   "user_id": "your_id_here",
   "user_pw": "your_password_here",
   "wait_after_login": 2,
-  "popup_selectors": ["#popupClose", "img[src*='popup_close']", "[class*='close']"]
+  "popup_selectors": ["#popupClose", "img[src*='popup_close']"]
 }


### PR DESCRIPTION
## Summary
- remove usage of general `[class*='close']` selectors
- rely on specific `#mainframe.HFrameSet00.VFrameSet00.FrameSet.WorkFrame.STZZ120_P0.form.btn_close:icontext` button
- simplify popup selectors configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587f5e67608320b3aa9b961bab34b8