### PR TITLE
Handle JS dialogs automatically

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -1,6 +1,7 @@
 import json
 import os
 from playwright.sync_api import sync_playwright
+from utils import setup_dialog_handler
 from dotenv import load_dotenv
 
 # Load environment variables from .env
@@ -37,6 +38,7 @@ def run() -> None:
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
         page = browser.new_page()
+        setup_dialog_handler(page)
         try:
             page.goto(url)
 

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from bs4 import BeautifulSoup
 from playwright.sync_api import sync_playwright
+from utils import setup_dialog_handler
 
 
 def main() -> None:
@@ -65,6 +66,7 @@ def main() -> None:
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
         page = browser.new_page()
+        setup_dialog_handler(page)
         try:
             page.goto(url)
 

--- a/structure_extractor.py
+++ b/structure_extractor.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from bs4 import BeautifulSoup
 from playwright.sync_api import sync_playwright
+from utils import setup_dialog_handler
 
 
 ATTRIBUTE_ORDER = ["id", "name", "placeholder", "aria-label"]
@@ -32,6 +33,7 @@ def extract_structure(url: str, output_path: str = "page_structure.json") -> Non
     with sync_playwright() as p:
         browser = p.chromium.launch()
         page = browser.new_page()
+        setup_dialog_handler(page)
         page.goto(url)
         page.wait_for_load_state("networkidle")
         html = page.content()

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ import time
 import subprocess
 import pyautogui
 import pygetwindow as gw
+from playwright.sync_api import Page
 
 # 공통 설정 및 유틸리티 함수 모음
 TESSERACT_CMD = r"C:\\Program Files\\Tesseract-OCR\\tesseract.exe"
@@ -69,3 +70,28 @@ def click_and_type(points: dict, point_key: str, text: str | None = None, tab_af
         pyautogui.press("tab")
         print("➡️ 탭키 전환됨")
     return x, y
+
+
+def setup_dialog_handler(page, auto_accept: bool = True) -> None:
+    """Register a Playwright dialog handler on the given page.
+
+    Parameters
+    ----------
+    page : playwright.sync_api.Page
+        The Playwright page object to attach the dialog listener to.
+    auto_accept : bool, optional
+        If True (default), automatically call ``accept()`` on dialogs.
+        If False, dialogs will be ``dismiss()`` instead.
+    """
+
+    def _handle(dialog) -> None:
+        try:
+            if auto_accept:
+                dialog.accept()
+            else:
+                dialog.dismiss()
+            print(f"자동 다이얼로그 처리: {dialog.message}")
+        except Exception as e:
+            print(f"다이얼로그 처리 오류: {e}")
+
+    page.on("dialog", _handle)


### PR DESCRIPTION
## Summary
- add dialog handler helper in `utils.py`
- register dialog handler in Playwright scripts

## Testing
- `python -m py_compile utils.py main.py codex_runner.py structure_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_685884af05908320b4a8f60622124f77