### PR TITLE
Handle multiple pop-ups before exiting

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -1,7 +1,7 @@
 import json
 import os
 from playwright.sync_api import sync_playwright
-from utils import setup_dialog_handler
+from utils import setup_dialog_handler, close_popups
 from dotenv import load_dotenv
 
 # Load environment variables from .env
@@ -80,6 +80,7 @@ def run() -> None:
             print(f"오류 발생: {e}")
         finally:
             try:
+                close_popups(page)
                 browser.close()
             finally:
                 print("정상 종료" if normal_exit else "비정상 종료")

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from bs4 import BeautifulSoup
 from playwright.sync_api import sync_playwright
-from utils import setup_dialog_handler
+from utils import setup_dialog_handler, close_popups
 
 
 def main() -> None:
@@ -124,6 +124,7 @@ def main() -> None:
             print(f"오류 발생: {e}")
         finally:
             try:
+                close_popups(page)
                 browser.close()
             finally:
                 print("정상 종료" if normal_exit else "비정상 종료")

--- a/navigate_sales_ratio.py
+++ b/navigate_sales_ratio.py
@@ -2,7 +2,7 @@ import json
 import os
 from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright
-from utils import setup_dialog_handler
+from utils import setup_dialog_handler, close_popups
 
 load_dotenv()
 
@@ -82,6 +82,7 @@ def run():
             print(f"오류 발생: {e}")
         finally:
             try:
+                close_popups(page)
                 browser.close()
             finally:
                 print("정상 종료" if normal_exit else "비정상 종료")

--- a/utils.py
+++ b/utils.py
@@ -95,3 +95,48 @@ def setup_dialog_handler(page, auto_accept: bool = True) -> None:
             print(f"다이얼로그 처리 오류: {e}")
 
     page.on("dialog", _handle)
+
+
+def close_popups(
+    page: Page,
+    repeat: int = 2,
+    interval: int = 1000,
+    final_wait: int = 3000,
+) -> int:
+    """Detect and close popups containing '닫기' text.
+
+    Parameters
+    ----------
+    page : Page
+        The Playwright page object to operate on.
+    repeat : int, optional
+        Number of passes to check for popups. Default is 2.
+    interval : int, optional
+        Delay between passes in milliseconds. Default is 1000.
+    final_wait : int, optional
+        Extra wait time in milliseconds after handling popups. Default is 3000.
+
+    Returns
+    -------
+    int
+        Total number of popups closed.
+    """
+
+    total_closed = 0
+    for attempt in range(repeat):
+        buttons = page.locator("div.nexacontentsbox:has-text('닫기')")
+        for i in range(buttons.count()):
+            btn = buttons.nth(i)
+            if btn.is_visible():
+                try:
+                    btn.click()
+                    total_closed += 1
+                    page.wait_for_timeout(500)
+                except Exception as e:  # pragma: no cover - simple logging
+                    print(f"팝업 닫기 실패: {e}")
+        if attempt < repeat - 1:
+            page.wait_for_timeout(interval)
+
+    print(f"총 {total_closed}개의 팝업 닫음")
+    page.wait_for_timeout(final_wait)
+    return total_closed


### PR DESCRIPTION
## Summary
- add `close_popups` helper to repeatedly click all '닫기' buttons
- use this helper in automation scripts before the browser closes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68589572ac008320b4a22601a1be8051