### PR TITLE
Add Monday check for sales analysis

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,9 @@ import os
 import glob
 import subprocess
 import sys
+import datetime
 from dotenv import load_dotenv
+from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
 
 # .env 파일 로드
 load_dotenv()
@@ -112,6 +114,10 @@ def main() -> None:
                     close_btn.click()
             except Exception as e:
                 print(f"STZZ120 팝업 닫기 실패: {e}")
+
+            # 월요일에만 매출 분석 기능 실행
+            if datetime.datetime.today().weekday() == 0:
+                navigate_sales_ratio(page)
 
             # ⑤ 정적 HTML 데이터 파싱 예시
             html = page.content()

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -1,5 +1,7 @@
 import json
 import os
+from pathlib import Path
+
 from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright
 from utils import setup_dialog_handler, close_popups
@@ -19,16 +21,17 @@ def click_sales_analysis_tab(page) -> bool:
 
 load_dotenv()
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+# 프로젝트 루트 디렉터리 경로
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 
 def load_config():
-    with open(os.path.join(BASE_DIR, "runtime_config.json"), "r", encoding="utf-8") as f:
+    with open(BASE_DIR / "runtime_config.json", "r", encoding="utf-8") as f:
         return json.load(f)
 
 
 def load_structure():
-    with open(os.path.join(BASE_DIR, "page_structure.json"), "r", encoding="utf-8") as f:
+    with open(BASE_DIR / "page_structure.json", "r", encoding="utf-8") as f:
         return json.load(f)
 
 


### PR DESCRIPTION
## Summary
- move sales analysis scripts into a new `sales_analysis` package
- update `navigate_sales_ratio.py` to use repo root for configs
- run sales analysis on Mondays only

## Testing
- `python -m py_compile main.py sales_analysis/navigate_sales_ratio.py`

------
https://chatgpt.com/codex/tasks/task_e_68589d0726c48320816d0ceac6eed67e