### PR TITLE
Ensure popups closed before actions

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -64,6 +64,8 @@ def run() -> None:
             else:
                 print("버튼 없음")
 
+            close_popups(page, repeat=3, interval=1000, max_wait=5000)
+
             # Additional popup handling for STZZ120 page
             try:
                 close_selector = (

--- a/main.py
+++ b/main.py
@@ -107,6 +107,9 @@ def main() -> None:
             else:
                 print("버튼 없음")
 
+            # 추가 안전 장치로 팝업을 반복적으로 닫음
+            close_popups(page, repeat=3, interval=1000, max_wait=5000)
+
             # STZZ120 페이지 팝업 닫기 처리
             try:
                 close_selector = (

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -91,6 +91,8 @@ def run():
                     page.locator(sel).click()
                     break
 
+            close_popups(page, repeat=3, interval=1000, max_wait=5000)
+
             navigate_sales_ratio(page)
             print("메뉴 이동 완료")
             normal_exit = True

--- a/utils.py
+++ b/utils.py
@@ -102,7 +102,7 @@ def close_popups(
     repeat: int = 3,
     interval: int = 1000,
     final_wait: int = 3000,
-    max_wait: int | None = None,
+    max_wait: int | None = 5000,
 ) -> int:
     """Detect and close popups on the page.
 
@@ -118,7 +118,7 @@ def close_popups(
         Extra wait time in milliseconds after handling popups. Default is 3000.
     max_wait : int | None, optional
         Maximum wait time in milliseconds for the overall routine. ``None`` means
-        no time limit.
+        no time limit. Default is ``5000``.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- guarantee closing popups before continuing automation
- expose default 5-second cap in `close_popups`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a27fb9288320911e4a0ba1223199