### PR TITLE
Add sales ratio detail extractor

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import sys
 import datetime
 from dotenv import load_dotenv
 from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
+from sales_analysis.sales_ratio_detail_extractor import extract_sales_ratio_details
 
 # .env 파일 로드
 load_dotenv()
@@ -119,6 +120,7 @@ def main() -> None:
             # 월요일에만 매출 분석 기능 실행
             if datetime.datetime.today().weekday() == 0:
                 navigate_sales_ratio(page)
+                extract_sales_ratio_details(page)
 
             # ⑤ 정적 HTML 데이터 파싱 예시
             html = page.content()

--- a/sales_analysis/__init__.py
+++ b/sales_analysis/__init__.py
@@ -1,0 +1,7 @@
+"""Sales analysis helper package."""
+
+from .navigate_sales_ratio import navigate_sales_ratio
+from .sales_ratio_detail_extractor import extract_sales_ratio_details
+
+__all__ = ["navigate_sales_ratio", "extract_sales_ratio_details"]
+

--- a/sales_analysis/sales_ratio_detail_extractor.py
+++ b/sales_analysis/sales_ratio_detail_extractor.py
@@ -1,0 +1,73 @@
+import datetime
+from pathlib import Path
+from playwright.sync_api import Page
+from utils import popups_handled
+
+
+def set_current_month_range(page: Page) -> tuple[str, str]:
+    """Set the date range to the first day of this month through today."""
+    today = datetime.date.today()
+    start = today.replace(day=1)
+    start_str = start.strftime("%Y-%m-%d")
+    end_str = today.strftime("%Y-%m-%d")
+
+    start_selectors = [
+        "input[name='fromDate']",
+        "input[name='startDate']",
+        "input[id*='frDate']",
+        "input[id*='start']",
+    ]
+    end_selectors = [
+        "input[name='toDate']",
+        "input[name='endDate']",
+        "input[id*='toDate']",
+        "input[id*='end']",
+    ]
+    button_selectors = ["button:has-text('조회')", "a:has-text('조회')"]
+
+    for sel in start_selectors:
+        locator = page.locator(sel)
+        if locator.count() > 0:
+            locator.first.fill(start_str)
+            break
+    for sel in end_selectors:
+        locator = page.locator(sel)
+        if locator.count() > 0:
+            locator.first.fill(end_str)
+            break
+    for sel in button_selectors:
+        locator = page.locator(sel)
+        if locator.count() > 0:
+            locator.first.click()
+            break
+    page.wait_for_load_state("networkidle")
+    return start_str, end_str
+
+
+def extract_sales_ratio_details(page: Page) -> Path:
+    """Extract detail table data for all middle categories."""
+    if not popups_handled():
+        raise RuntimeError("팝업 처리가 완료되지 않았습니다.")
+
+    start_str, end_str = set_current_month_range(page)
+
+    left_rows = page.locator("table tr")
+    row_count = left_rows.count()
+
+    output_dir = Path(__file__).resolve().parent
+    file_name = f"중분류상세매출_{end_str}.txt"
+    out_path = output_dir / file_name
+
+    with out_path.open("w", encoding="utf-8") as f:
+        for i in range(row_count):
+            row = left_rows.nth(i)
+            category = row.inner_text().strip()
+            row.click()
+            page.wait_for_timeout(500)
+            details = page.locator("table:has(th:text('상품명')) tr")
+            texts = [d.inner_text().strip() for d in details.all()]
+            f.write(f"[중분류: {category}]\n")
+            for line in texts:
+                f.write(line + "\n")
+            f.write("\n")
+    return out_path


### PR DESCRIPTION
## Summary
- expose navigate and extractor in sales_analysis package
- add `sales_ratio_detail_extractor` module
- call extractor from `main.py`

## Testing
- `python -m py_compile sales_analysis/sales_ratio_detail_extractor.py sales_analysis/__init__.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6858a9fa680c8320a27dad40fe1df33d