### PR TITLE
Improve logging and popup handling

### DIFF
--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright
-from utils import setup_dialog_handler, close_popups, popups_handled
+from utils import setup_dialog_handler, close_popups, popups_handled, log
 
 
 def click_sales_analysis_tab(page) -> bool:
@@ -13,10 +13,10 @@ def click_sales_analysis_tab(page) -> bool:
     try:
         element = page.wait_for_selector(selector, timeout=5000)
         element.click()
-        print("'매출분석' 탭 클릭 성공")
+        log("'매출분석' 탭 클릭 성공")
         return True
     except Exception as e:
-        print(f"'매출분석' 탭 클릭 실패: {e}")
+        log(f"'매출분석' 탭 클릭 실패: {e}")
         return False
 
 load_dotenv()
@@ -63,7 +63,7 @@ def run():
     user_pw = os.getenv("LOGIN_PW")
 
     if not user_id or not user_pw:
-        print("LOGIN_ID 또는 LOGIN_PW가 설정되지 않았습니다.")
+        log("LOGIN_ID 또는 LOGIN_PW가 설정되지 않았습니다.")
         return
 
     url = "https://store.bgfretail.com/websrc/deploy/index.html"
@@ -87,27 +87,26 @@ def run():
                 page.wait_for_timeout(wait_after_login * 1000)
 
             closed = 0
-            for _ in range(3):
-                closed += close_popups(page, repeat=1, interval=500, max_wait=3000)
-                if popups_handled():
-                    break
+            for attempt in range(3):
+                log(f"팝업 탐색 {attempt + 1}회차")
+                closed += close_popups(page, repeat=2, interval=500, max_wait=3000, force=True)
                 page.wait_for_timeout(1000)
             if popups_handled():
-                print("✅ 모든 팝업 처리 완료")
+                log("✅ 모든 팝업 처리 완료")
             else:
-                print("⚠️ 일부 팝업이 닫히지 않았습니다")
+                log("⚠️ 일부 팝업이 닫히지 않았습니다")
 
             navigate_sales_ratio(page)
-            print("메뉴 이동 완료")
+            log("메뉴 이동 완료")
             normal_exit = True
         except Exception as e:
-            print(f"오류 발생: {e}")
+            log(f"오류 발생: {e}")
         finally:
             try:
                 close_popups(page, force=True)
                 browser.close()
             finally:
-                print("정상 종료" if normal_exit else "비정상 종료")
+                log("정상 종료" if normal_exit else "비정상 종료")
 
 
 if __name__ == "__main__":

--- a/sales_analysis/sales_ratio_detail_extractor.py
+++ b/sales_analysis/sales_ratio_detail_extractor.py
@@ -1,7 +1,7 @@
 import datetime
 from pathlib import Path
 from playwright.sync_api import Page
-from utils import popups_handled
+from utils import popups_handled, log
 
 
 def set_current_month_range(page: Page) -> tuple[str, str]:
@@ -49,7 +49,10 @@ def extract_sales_ratio_details(page: Page) -> Path:
     if not popups_handled():
         raise RuntimeError("팝업 처리가 완료되지 않았습니다.")
 
+    log("🟡 매출상세 추출을 위한 날짜 범위 설정")
     start_str, end_str = set_current_month_range(page)
+
+    log("🟡 중분류 테이블 파싱 시작")
 
     left_rows = page.locator("table tr")
     row_count = left_rows.count()
@@ -70,4 +73,5 @@ def extract_sales_ratio_details(page: Page) -> Path:
             for line in texts:
                 f.write(line + "\n")
             f.write("\n")
+    log(f"✅ 매출상세 데이터 저장 완료 → {out_path}")
     return out_path

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import subprocess
+import datetime
 import pyautogui
 import pygetwindow as gw
 from playwright.sync_api import Page
@@ -9,6 +10,12 @@ from playwright.sync_api import Page
 # 팝업 처리 상태를 추적하기 위한 전역 변수
 EXPECTED_POPUPS = 2
 _closed_popups = 0
+
+
+def log(msg: str) -> None:
+    """Print a log message with current time."""
+    timestamp = datetime.datetime.now().strftime("%H:%M:%S")
+    print(f"[{timestamp}] {msg}")
 
 
 def popups_handled() -> bool:
@@ -143,7 +150,7 @@ def close_popups(
     global _closed_popups
 
     if _closed_popups >= EXPECTED_POPUPS and not force:
-        print("✅ 모든 팝업 이미 처리됨, 추가 닫기 생략")
+        log("✅ 모든 팝업 이미 처리됨, 추가 닫기 생략")
         return 0
 
     selectors = [
@@ -185,7 +192,7 @@ def close_popups(
                         total_closed += 1
                         frame.wait_for_timeout(800)
                     except Exception as e:  # pragma: no cover - simple logging
-                        print(f"팝업 닫기 실패: {e}")
+                        log(f"팝업 닫기 실패: {e}")
         attempts += 1
         elapsed = (time.time() - start) * 1000
         if (max_wait is not None and elapsed >= max_wait) or attempts >= repeat:
@@ -194,9 +201,9 @@ def close_popups(
 
     _closed_popups += total_closed
 
-    print(f"총 {total_closed}개 팝업 닫기, 감지된 버튼 {total_detected}개")
+    log(f"총 {total_closed}개 팝업 닫기, 감지된 버튼 {total_detected}개")
     if total_closed < total_detected:
-        print(f"⚠️ 닫히지 않은 팝업 버튼 {total_detected - total_closed}개 존재")
+        log(f"⚠️ 닫히지 않은 팝업 버튼 {total_detected - total_closed}개 존재")
 
     page.wait_for_timeout(final_wait)
     return total_closed


### PR DESCRIPTION
## Summary
- track progress with timestamps using new `log` helper
- ensure popups loops run and show progress in `main.py`
- add detailed messages for sales analysis navigation
- report progress while extracting sales ratio details

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ab8f4ce883208cecbdf01d9b1cab