### PR TITLE
Implement sales detail extraction

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import sys
 import datetime
 from dotenv import load_dotenv
 from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
-from sales_analysis.sales_ratio_detail_extractor import extract_sales_ratio_details
+from sales_analysis.extract_sales_detail import extract_sales_detail
 
 # .env 파일 로드
 load_dotenv()
@@ -129,7 +129,7 @@ def main() -> None:
 
                 try:
                     log("🟡 매출 상세 데이터 추출 시작")
-                    extract_sales_ratio_details(page)
+                    extract_sales_detail(page)
                     log("✅ 매출 상세 데이터 추출 완료")
                 except Exception as e:
                     log(f"❗ 데이터 추출 실패: {e}")

--- a/sales_analysis/__init__.py
+++ b/sales_analysis/__init__.py
@@ -2,6 +2,10 @@
 
 from .navigate_sales_ratio import navigate_sales_ratio
 from .sales_ratio_detail_extractor import extract_sales_ratio_details
+from .extract_sales_detail import extract_sales_detail
 
-__all__ = ["navigate_sales_ratio", "extract_sales_ratio_details"]
-
+__all__ = [
+    "navigate_sales_ratio",
+    "extract_sales_ratio_details",
+    "extract_sales_detail",
+]

--- a/sales_analysis/extract_sales_detail.py
+++ b/sales_analysis/extract_sales_detail.py
@@ -1,0 +1,70 @@
+import datetime
+from pathlib import Path
+from playwright.sync_api import Page
+from utils import popups_handled, log
+
+
+def set_month_date_range(page: Page) -> tuple[str, str]:
+    """Set the from/to date fields to the first day of this month through today."""
+    today = datetime.date.today()
+    start = today.replace(day=1)
+    start_str = start.strftime("%Y-%m-%d")
+    end_str = today.strftime("%Y-%m-%d")
+
+    start_input = page.locator("input[id$='calFromDay.calendaredit:input']")
+    if start_input.count() > 0:
+        start_input.click()
+        start_input.fill(start_str)
+        start_input.press("Enter")
+
+    end_input = page.locator("input[id$='calToDay.calendaredit:input']")
+    if end_input.count() > 0:
+        end_input.click()
+        end_input.fill(end_str)
+        end_input.press("Enter")
+
+    return start_str, end_str
+
+
+def extract_sales_detail(page: Page) -> Path:
+    """Extract daily sales details for each middle category."""
+    if not popups_handled():
+        raise RuntimeError("팝업 처리가 완료되지 않았습니다.")
+
+    log("🟡 날짜 설정 시작")
+    start_str, end_str = set_month_date_range(page)
+
+    search_btn = page.locator("div.nexacontentsbox:has-text('조 회')")
+    if search_btn.count() > 0:
+        search_btn.first.click()
+        page.wait_for_load_state("networkidle")
+    else:
+        log("⚠️ 조회 버튼을 찾을 수 없습니다")
+
+    left_rows = page.locator("div[class^='gridrow_'] .cell_0_0")
+    row_count = left_rows.count()
+
+    output_dir = Path(__file__).resolve().parent
+    file_name = f"중분류상세매출_{end_str}.txt"
+    out_path = output_dir / file_name
+
+    log("🟡 중분류별 매출 상세 추출 시작")
+    with out_path.open("w", encoding="utf-8") as f:
+        for i in range(row_count):
+            row = left_rows.nth(i)
+            code = row.inner_text().strip()
+            row.click()
+            page.wait_for_timeout(500)
+
+            details = page.locator("#gdDetail div[class^='gridrow_']")
+            detail_count = details.count()
+            f.write(f"[중분류: {code}]\n")
+            for j in range(detail_count):
+                d_row = details.nth(j)
+                text = d_row.inner_text().replace("\n", "\t").strip()
+                if text:
+                    f.write(text + "\n")
+            f.write("\n")
+
+    log(f"✅ 매출상세 데이터 저장 → {out_path}")
+    return out_path


### PR DESCRIPTION
## Summary
- add `extract_sales_detail` to parse middle-category sales data
- expose the new helper in the sales_analysis package
- call the extractor from `main.py` instead of the previous stub

## Testing
- `python -m py_compile sales_analysis/extract_sales_detail.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b302ef38832083af56dc05d714ca