### PR TITLE
Improve popup workflow and data extraction

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -1,7 +1,12 @@
 import json
 import os
 from playwright.sync_api import sync_playwright
-from utils import setup_dialog_handler, close_popups, popups_handled
+from utils import (
+    setup_dialog_handler,
+    close_popups,
+    popups_handled,
+    process_popups_once,
+)
 from dotenv import load_dotenv
 
 # Load environment variables from .env
@@ -52,16 +57,11 @@ def run() -> None:
             if wait_after_login:
                 page.wait_for_timeout(wait_after_login * 1000)
 
-            closed = 0
-            for _ in range(3):
-                closed += close_popups(page, repeat=1, interval=500, max_wait=3000)
-                if popups_handled():
-                    break
-                page.wait_for_timeout(1000)
-            if popups_handled():
-                print("✅ 모든 팝업 처리 완료")
-            else:
+            if not process_popups_once(page):
                 print("⚠️ 일부 팝업이 닫히지 않았습니다")
+                return
+            else:
+                print("✅ 모든 팝업 처리 완료")
 
             # Additional popup handling for STZZ120 page
             try:

--- a/main.py
+++ b/main.py
@@ -17,7 +17,13 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 from bs4 import BeautifulSoup
 from playwright.sync_api import sync_playwright
-from utils import setup_dialog_handler, close_popups, popups_handled, log
+from utils import (
+    setup_dialog_handler,
+    close_popups,
+    popups_handled,
+    process_popups_once,
+    log,
+)
 
 
 def main() -> None:
@@ -94,16 +100,10 @@ def main() -> None:
             if wait_after_login:
                 page.wait_for_timeout(wait_after_login * 1000)
 
-            log("🟡 팝업 닫기 루프 시작")
-            closed = 0
-            for attempt in range(3):
-                log(f"  ➡️ 팝업 탐색 {attempt + 1}회차")
-                closed += close_popups(page, repeat=2, interval=500, max_wait=3000, force=True)
-                page.wait_for_timeout(1000)
-            if popups_handled():
-                log("✅ 팝업 처리 완료, 다음 단계로 이동 중...")
-            else:
-                log("⚠️ 일부 팝업이 닫히지 않았습니다")
+            log("🟡 팝업 처리 시작")
+            if not process_popups_once(page):
+                log("❌ 팝업을 모두 닫지 못해 종료합니다")
+                return
 
             log("🟡 STZZ120 팝업 닫기 시도")
             try:

--- a/sales_analysis/extract_sales_detail.py
+++ b/sales_analysis/extract_sales_detail.py
@@ -49,6 +49,7 @@ def extract_sales_detail(page: Page) -> Path:
     out_path = output_dir / file_name
 
     log("🟡 중분류별 매출 상세 추출 시작")
+    total_details = 0
     with out_path.open("w", encoding="utf-8") as f:
         for i in range(row_count):
             row = left_rows.nth(i)
@@ -56,8 +57,14 @@ def extract_sales_detail(page: Page) -> Path:
             row.click()
             page.wait_for_timeout(500)
 
+            container = page.locator("div[id*='gdDetail']")
             details = page.locator("#gdDetail div[class^='gridrow_']")
+            if container.count() == 0 or details.count() == 0:
+                log("❌ 상세 테이블 항목 없음")
+                continue
+
             detail_count = details.count()
+            total_details += detail_count
             f.write(f"[중분류: {code}]\n")
             for j in range(detail_count):
                 d_row = details.nth(j)
@@ -66,5 +73,6 @@ def extract_sales_detail(page: Page) -> Path:
                     f.write(text + "\n")
             f.write("\n")
 
-    log(f"✅ 매출상세 데이터 저장 → {out_path}")
+    if total_details > 0:
+        log(f"✅ 매출상세 데이터 저장 → {out_path}")
     return out_path

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright
-from utils import setup_dialog_handler, close_popups, popups_handled, log
+from utils import (
+    setup_dialog_handler,
+    close_popups,
+    popups_handled,
+    process_popups_once,
+    log,
+)
 
 
 def click_sales_analysis_tab(page) -> bool:
@@ -86,15 +92,9 @@ def run():
             if wait_after_login:
                 page.wait_for_timeout(wait_after_login * 1000)
 
-            closed = 0
-            for attempt in range(3):
-                log(f"팝업 탐색 {attempt + 1}회차")
-                closed += close_popups(page, repeat=2, interval=500, max_wait=3000, force=True)
-                page.wait_for_timeout(1000)
-            if popups_handled():
-                log("✅ 모든 팝업 처리 완료")
-            else:
-                log("⚠️ 일부 팝업이 닫히지 않았습니다")
+            if not process_popups_once(page):
+                log("❌ 팝업을 모두 닫지 못했습니다")
+                return
 
             navigate_sales_ratio(page)
             log("메뉴 이동 완료")


### PR DESCRIPTION
## Summary
- ensure popup search only runs once across the program
- exit early if popups remain open
- log remaining popups and success only when all popups close
- skip success log if detail table missing when saving sales details

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858b73415048320a303b2d12b369e15