### PR TITLE
Improve popup closing reliability

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,8 +112,12 @@ def main() -> None:
                 )
                 close_btn = page.locator(close_selector)
                 if close_btn.count() > 0 and close_btn.is_visible():
+                    page.evaluate("document.getElementById('nexacontainer').style.pointerEvents = 'none'")
                     close_btn.click(timeout=3000)
+                    page.evaluate("document.getElementById('nexacontainer').style.pointerEvents = ''")
                     log("✅ STZZ120 팝업 닫기 완료")
+                # 추가 팝업 존재 여부 재확인
+                close_popups(page, repeat=2, interval=500, force=True)
             except Exception as e:
                 log(f"❗ STZZ120 팝업 닫기 실패: {e}")
 

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -53,6 +53,8 @@ def find_and_click(page, text: str) -> bool:
 
 
 def navigate_sales_ratio(page):
+    if not popups_handled():
+        raise RuntimeError("팝업 처리가 완료되지 않았습니다")
     if not click_sales_analysis_tab(page):
         raise RuntimeError("Cannot find '매출분석' menu")
     page.wait_for_timeout(1000)


### PR DESCRIPTION
## Summary
- disable pointer events when clicking popups and restore afterwards
- log overlay obstruction when popup close fails
- warn when many popups remain and automatically run a fallback strategy
- ensure STZZ120 popup close also disables pointer events
- guard menu navigation with popup completion check

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6858b8d8549083208e22c6c9f2e4d114