### PR TITLE
Add overlay cleanup init script

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -6,6 +6,7 @@ from utils import (
     close_popups,
     popups_handled,
     process_popups_once,
+    inject_init_cleanup_script,
 )
 from dotenv import load_dotenv
 
@@ -43,6 +44,7 @@ def run() -> None:
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
         page = browser.new_page()
+        inject_init_cleanup_script(page)
         setup_dialog_handler(page)
         try:
             page.goto(url)

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from utils import (
     popups_handled,
     process_popups_once,
     close_stzz120_popup,
+    inject_init_cleanup_script,
     log,
 )
 
@@ -78,6 +79,7 @@ def main() -> None:
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
         page = browser.new_page()
+        inject_init_cleanup_script(page)
         log("✅ 브라우저 페이지 생성 완료")
         setup_dialog_handler(page)
         try:

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -9,6 +9,7 @@ from utils import (
     close_popups,
     popups_handled,
     process_popups_once,
+    inject_init_cleanup_script,
     log,
 )
 
@@ -80,6 +81,7 @@ def run():
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
         page = browser.new_page()
+        inject_init_cleanup_script(page)
         setup_dialog_handler(page)
         try:
             page.goto(url)

--- a/structure_extractor.py
+++ b/structure_extractor.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from bs4 import BeautifulSoup
 from playwright.sync_api import sync_playwright
-from utils import setup_dialog_handler
+from utils import setup_dialog_handler, inject_init_cleanup_script
 
 
 ATTRIBUTE_ORDER = ["id", "name", "placeholder", "aria-label"]
@@ -33,6 +33,7 @@ def extract_structure(url: str, output_path: str = "page_structure.json") -> Non
     with sync_playwright() as p:
         browser = p.chromium.launch()
         page = browser.new_page()
+        inject_init_cleanup_script(page)
         setup_dialog_handler(page)
         page.goto(url)
         page.wait_for_load_state("networkidle")

--- a/utils.py
+++ b/utils.py
@@ -25,6 +25,21 @@ def popups_handled() -> bool:
     """Return ``True`` if expected popups were already closed."""
     return _closed_popups >= EXPECTED_POPUPS
 
+
+def inject_init_cleanup_script(page: Page) -> None:
+    """Inject a script that removes overlays and closing popups on load."""
+    page.add_init_script(
+        """
+        document.addEventListener("DOMContentLoaded", () => {
+            document
+                .querySelectorAll(
+                    "div.nexamodaloverlay, div.nexacontentsbox:has-text('닫기')"
+                )
+                .forEach((el) => el.remove());
+        });
+        """
+    )
+
 # 공통 설정 및 유틸리티 함수 모음
 TESSERACT_CMD = r"C:\\Program Files\\Tesseract-OCR\\tesseract.exe"
 CHROME_PATH = r"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"


### PR DESCRIPTION
## Summary
- inject a DOMContentLoaded cleanup script via `page.add_init_script`
- call cleanup injection after creating pages across main and helper modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ca43a2b483209ebdb7f7596f0be9