### PR TITLE
Add middle category product extractor

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,9 @@ import datetime
 from dotenv import load_dotenv
 from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
 from sales_analysis.extract_sales_detail import extract_sales_detail
+from sales_analysis.middle_category_product_extractor import (
+    extract_middle_category_products,
+)
 
 # .env 파일 로드
 load_dotenv()
@@ -104,8 +107,13 @@ def main() -> None:
                 page.wait_for_timeout(wait_after_login * 1000)
 
             log("🟡 팝업 처리 시작")
-            if not process_popups_once(page):
-                log("⚠️ 팝업을 모두 닫지 못했으나 계속 진행합니다")
+            attempts = 0
+            while not popups_handled() and attempts < 3:
+                process_popups_once(page, force=True)
+                attempts += 1
+            if not popups_handled():
+                log("❗ 팝업을 모두 닫지 못했습니다. 자동화를 종료합니다")
+                return
 
             log("🟡 STZZ120 팝업 닫기 시도")
             try:
@@ -129,6 +137,7 @@ def main() -> None:
                     log("🟡 매출 상세 데이터 추출 시작")
                     extract_sales_detail(page)
                     log("✅ 매출 상세 데이터 추출 완료")
+                    extract_middle_category_products(page)
                 except Exception as e:
                     log(f"❗ 데이터 추출 실패: {e}")
                     raise

--- a/sales_analysis/__init__.py
+++ b/sales_analysis/__init__.py
@@ -3,9 +3,11 @@
 from .navigate_sales_ratio import navigate_sales_ratio
 from .sales_ratio_detail_extractor import extract_sales_ratio_details
 from .extract_sales_detail import extract_sales_detail
+from .middle_category_product_extractor import extract_middle_category_products
 
 __all__ = [
     "navigate_sales_ratio",
     "extract_sales_ratio_details",
     "extract_sales_detail",
+    "extract_middle_category_products",
 ]

--- a/sales_analysis/middle_category_product_extractor.py
+++ b/sales_analysis/middle_category_product_extractor.py
@@ -1,0 +1,53 @@
+import json
+import datetime
+from pathlib import Path
+from playwright.sync_api import Page
+from utils import popups_handled, log
+
+
+def extract_middle_category_products(page: Page) -> Path:
+    """Extract product codes and names for each middle category.
+
+    Parameters
+    ----------
+    page : Page
+        Playwright page already navigated to the middle category sales page.
+
+    Returns
+    -------
+    Path
+        Path to the saved JSON file.
+    """
+    if not popups_handled():
+        raise RuntimeError("팝업 처리가 완료되지 않았습니다.")
+
+    left_rows = page.locator("div[class^='gridrow_'] .cell_0_0")
+    row_count = left_rows.count()
+
+    result: list[dict] = []
+    for i in range(row_count):
+        row = left_rows.nth(i)
+        category = row.inner_text().strip()
+        row.click()
+        page.wait_for_timeout(500)
+
+        detail_rows = page.locator("#gdDetail div[class^='gridrow_']")
+        products: list[dict] = []
+        for j in range(detail_rows.count()):
+            d_row = detail_rows.nth(j)
+            cells = d_row.locator("div")
+            if cells.count() >= 2:
+                code = cells.nth(0).inner_text().strip()
+                name = cells.nth(1).inner_text().strip()
+                if code and name:
+                    products.append({"code": code, "name": name})
+        result.append({"category": category, "products": products})
+
+    output_dir = Path(__file__).resolve().parent
+    file_name = f"중분류상품_{datetime.date.today():%Y%m%d}.json"
+    out_path = output_dir / file_name
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    log(f"✅ 상품코드 및 상품명 저장 → {out_path}")
+    return out_path


### PR DESCRIPTION
## Summary
- enforce that all popups are closed before proceeding
- extract product codes and names for middle categories

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6858d63589f88320960395a26bf2212c