### PR TITLE
Update popup fallback and enforce prechecks

### DIFF
--- a/sales_analysis/extract_sales_detail.py
+++ b/sales_analysis/extract_sales_detail.py
@@ -29,7 +29,7 @@ def set_month_date_range(page: Page) -> tuple[str, str]:
 def extract_sales_detail(page: Page) -> Path:
     """Extract daily sales details for each middle category."""
     if not popups_handled():
-        log("⚠️ 팝업이 남아 있지만 데이터 추출을 시도합니다")
+        raise RuntimeError("팝업 처리가 완료되지 않아 데이터 추출을 중단합니다")
 
     log("🟡 날짜 설정 시작")
     start_str, end_str = set_month_date_range(page)

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -55,7 +55,7 @@ def find_and_click(page, text: str) -> bool:
 
 def navigate_sales_ratio(page):
     if not popups_handled():
-        log("⚠️ 팝업이 남아 있지만 메뉴 이동을 시도합니다")
+        raise RuntimeError("팝업 처리가 완료되지 않아 메뉴 이동을 중단합니다")
     if not click_sales_analysis_tab(page):
         raise RuntimeError("Cannot find '매출분석' menu")
     page.wait_for_timeout(1000)

--- a/utils.py
+++ b/utils.py
@@ -135,10 +135,12 @@ def fallback_close_popups(page: Page) -> None:
     """Alternative popup closing strategy using ESC key and element removal."""
     log("⬇️ 팝업 강제 종료 전략 실행")
     try:
-        for frame in [page, *page.frames]:
-            frame.hover("body")
-            frame.keyboard.press("Escape")
-            frame.wait_for_timeout(300)
+        try:
+            page.hover("body")
+            page.keyboard.press("Escape")
+            page.wait_for_timeout(300)
+        except Exception as e:
+            log(f"ESC 키 전송 실패: {e}")
         divs = page.locator("div[style*='z-index']")
         for i in range(divs.count()):
             d = divs.nth(i)


### PR DESCRIPTION
## Summary
- use the page object when issuing escape key for fallback popup closing
- prevent navigation and extraction if popups are not yet handled

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858d8165ed88320aa876f925b1e4e7a