### PR TITLE
Improve popup handling robustness

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ from utils import (
     process_popups_once,
     close_stzz120_popup,
     inject_init_cleanup_script,
+    set_ignore_popup_failure,
     log,
 )
 
@@ -50,6 +51,8 @@ def main() -> None:
         "popup_selectors",
         ["#popupClose", "img[src*='popup_close']"],
     )
+    ignore_popup_failure = runtime_config.get("ignore_popup_failure", False)
+    set_ignore_popup_failure(ignore_popup_failure)
 
     structure_file = os.path.join(BASE_DIR, "page_structure.json")
     if not os.path.exists(structure_file):
@@ -112,8 +115,11 @@ def main() -> None:
                 process_popups_once(page, force=True)
                 attempts += 1
             if not popups_handled():
-                log("❗ 팝업을 모두 닫지 못했습니다. 자동화를 종료합니다")
-                return
+                if ignore_popup_failure:
+                    log("⚠️ 팝업을 모두 닫지 못했으나 계속 진행합니다")
+                else:
+                    log("❗ 팝업을 모두 닫지 못했습니다. 자동화를 종료합니다")
+                    return
 
             log("🟡 STZZ120 팝업 닫기 시도")
             try:
@@ -122,6 +128,12 @@ def main() -> None:
                 close_popups(page, repeat=4, interval=1000, force=True)
             except Exception as e:
                 log(f"❗ STZZ120 팝업 닫기 실패: {e}")
+            if not popups_handled():
+                if ignore_popup_failure:
+                    log("⚠️ 일부 팝업이 남아 있지만 계속 진행합니다")
+                else:
+                    log("❗ 팝업 처리가 완료되지 않아 자동화를 종료합니다")
+                    return
 
             # 월요일에만 매출 분석 기능 실행
             if datetime.datetime.today().weekday() == 0:

--- a/runtime_config.json
+++ b/runtime_config.json
@@ -2,5 +2,6 @@
   "user_id": "your_id_here",
   "user_pw": "your_password_here",
   "wait_after_login": 2,
-  "popup_selectors": ["#popupClose", "img[src*='popup_close']"]
+  "popup_selectors": ["#popupClose", "img[src*='popup_close']"],
+  "ignore_popup_failure": false
 }

--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,13 @@ _closed_popups = 0
 _processed_popups = False
 # 팝업 닫기 실패가 연속 발생한 횟수
 _popup_failure_count = 0
+_ignore_popup_failure = False
+
+
+def set_ignore_popup_failure(value: bool) -> None:
+    """Set whether popup failures should be ignored."""
+    global _ignore_popup_failure
+    _ignore_popup_failure = value
 
 
 def log(msg: str) -> None:
@@ -22,8 +29,8 @@ def log(msg: str) -> None:
 
 
 def popups_handled() -> bool:
-    """Return ``True`` if expected popups were already closed."""
-    return _closed_popups >= EXPECTED_POPUPS
+    """Return ``True`` if expected popups were already closed or ignored."""
+    return _ignore_popup_failure or _closed_popups >= EXPECTED_POPUPS
 
 
 def inject_init_cleanup_script(page: Page) -> None:
@@ -238,12 +245,26 @@ def close_popups(
         "text=닫습니다",
         "button:has-text('닫기')",
         "[role='button']:has-text('닫기')",
+        "a:has-text('닫기')",
+        "[aria-label='닫기']",
+        "button:has-text('Close')",
+        "[aria-label='close']",
+        "button:has-text('✕')",
+        "text=✕",
     ]
     attr_selectors = [
         "button[id*='close']",
         "button[class*='close']",
+        "a[class*='close']",
+        "div[class*='close']",
+        "span[class*='close']",
         "[role='button'][id*='close']",
         "[role='button'][class*='close']",
+        "button.close",
+        "a.close",
+        ".btn-close",
+        ".modal-close",
+        "[data-dismiss='modal']",
     ]
     selectors = text_selectors + attr_selectors
 
@@ -303,12 +324,26 @@ def remaining_popup_button_ids(page: Page) -> list[str]:
         "text=닫습니다",
         "button:has-text('닫기')",
         "[role='button']:has-text('닫기')",
+        "a:has-text('닫기')",
+        "[aria-label='닫기']",
+        "button:has-text('Close')",
+        "[aria-label='close']",
+        "button:has-text('✕')",
+        "text=✕",
     ]
     attr_selectors = [
         "button[id*='close']",
         "button[class*='close']",
+        "a[class*='close']",
+        "div[class*='close']",
+        "span[class*='close']",
         "[role='button'][id*='close']",
         "[role='button'][class*='close']",
+        "button.close",
+        "a.close",
+        ".btn-close",
+        ".modal-close",
+        "[data-dismiss='modal']",
     ]
     selectors = text_selectors + attr_selectors
 


### PR DESCRIPTION
## Summary
- allow ignoring popup failures via new config `ignore_popup_failure`
- enhance popup search selectors for better detection
- integrate ignore option in main popup workflow

## Testing
- `python -m py_compile main.py utils.py`
- `python codex_runner.py` *(fails: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_6858df9137e48320b79798abff433bcf