### PR TITLE
Implement single-run popup handler

### DIFF
--- a/codex_runner.py
+++ b/codex_runner.py
@@ -5,7 +5,7 @@ from utils import (
     setup_dialog_handler,
     close_popups,
     popups_handled,
-    process_popups_once,
+    handle_popup,
     inject_init_cleanup_script,
 )
 from dotenv import load_dotenv
@@ -59,8 +59,11 @@ def run() -> None:
             if wait_after_login:
                 page.wait_for_timeout(wait_after_login * 1000)
 
-            if not process_popups_once(page):
-                print("⚠️ 일부 팝업이 닫히지 않았으나 계속 진행합니다")
+            if not popups_handled():
+                if not handle_popup(page):
+                    print("⚠️ 일부 팝업이 닫히지 않았으나 계속 진행합니다")
+                else:
+                    print("✅ 모든 팝업 처리 완료")
             else:
                 print("✅ 모든 팝업 처리 완료")
 

--- a/main.py
+++ b/main.py
@@ -24,8 +24,7 @@ from utils import (
     setup_dialog_handler,
     close_popups,
     popups_handled,
-    process_popups_once,
-    close_stzz120_popup,
+    handle_popup,
     inject_init_cleanup_script,
     set_ignore_popup_failure,
     log,
@@ -110,32 +109,11 @@ def main() -> None:
                 page.wait_for_timeout(wait_after_login * 1000)
 
             log("🟡 팝업 처리 시작")
-            attempts = 0
-            while attempts < 2 or (not popups_handled() and attempts < 3):
-                try:
-                    process_popups_once(page, force=True)
-                except Exception as e:
-                    log(f"팝업 처리 중 오류: {e}")
-                attempts += 1
             if not popups_handled():
-                log("❗ 팝업을 모두 닫지 못해 자동화를 중단합니다")
-                return
-            else:
-                log("✅ 팝업 처리 완료")
-
-            log("🟡 STZZ120 팝업 닫기 시도")
-            try:
-                close_stzz120_popup(page)
-                # 추가 팝업 존재 여부 재확인
-                try:
-                    close_popups(page, repeat=4, interval=1000, force=True)
-                except Exception as e:
-                    log(f"추가 팝업 닫기 중 오류: {e}")
-            except Exception as e:
-                log(f"❗ STZZ120 팝업 닫기 실패: {e}")
-            if not popups_handled():
-                log("❗ 팝업이 남아 있어 자동화를 중단합니다")
-                return
+                if not handle_popup(page):
+                    log("❗ 팝업을 모두 닫지 못해 자동화를 중단합니다")
+                    return
+            log("✅ 팝업 처리 완료")
 
             # 월요일에만 매출 분석 기능 실행
             if datetime.datetime.today().weekday() == 0:

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -8,7 +8,7 @@ from utils import (
     setup_dialog_handler,
     close_popups,
     popups_handled,
-    process_popups_once,
+    handle_popup,
     inject_init_cleanup_script,
     log,
 )
@@ -96,8 +96,10 @@ def run():
             if wait_after_login:
                 page.wait_for_timeout(wait_after_login * 1000)
 
-            if not process_popups_once(page):
-                log("⚠️ 팝업을 모두 닫지 못했으나 계속 진행합니다")
+            if not popups_handled():
+                if not handle_popup(page):
+                    log("❗ 팝업을 모두 닫지 못해 작업을 중단합니다")
+                    return
 
             navigate_sales_ratio(page)
             log("메뉴 이동 완료")


### PR DESCRIPTION
## Summary
- manage popup state with new `popup_handled` global
- create `handle_popup` to close all popups once
- use the new popup handler in main automation flow
- ensure sales ratio navigation and Codex runner rely on the new handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ea0f1f848320a85d949e4311de3c