### PR TITLE
Refactor popup handling into dedicated module

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ from utils import (
     set_ignore_popup_failure,
     log,
 )
-from popup_handler import close_detected_popups
+from handlers.popup_handler import close_detected_popups
 
 
 def main() -> None:
@@ -45,10 +45,6 @@ def main() -> None:
     user_pw = os.getenv("LOGIN_PW")
 
     wait_after_login = runtime_config.get("wait_after_login", 0)
-    popup_selectors = runtime_config.get(
-        "popup_selectors",
-        ["#popupClose", "img[src*='popup_close']"],
-    )
     ignore_popup_failure = runtime_config.get("ignore_popup_failure", False)
     set_ignore_popup_failure(ignore_popup_failure)
 


### PR DESCRIPTION
## Summary
- move `popup_handler.py` into new `handlers` package
- expose `close_detected_popups` from the new module and keep main slim
- add `handle_text_popups` helper for text-based popups
- adjust imports in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^popup_handler.py$')`

------
https://chatgpt.com/codex/tasks/task_e_6858f824528c8320bacbd351362670e5