### PR TITLE
Handle blocked dialog message

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,11 @@ from utils import (
     set_ignore_popup_failure,
     log,
 )
-from handlers.popup_handler import close_detected_popups
+from handlers.popup_handler import (
+    close_detected_popups,
+    dialog_blocked,
+    login_page_visible,
+)
 
 
 def main() -> None:
@@ -106,6 +110,9 @@ def main() -> None:
             log("🟡 팝업 처리 시작")
             if not close_detected_popups(page):
                 log("❗ 팝업을 모두 닫지 못해 자동화를 중단합니다")
+                return
+            if dialog_blocked(page) or login_page_visible(page):
+                log("❗ 차단 메시지 또는 로그인 페이지 감지되어 종료합니다")
                 return
             log("✅ 팝업 처리 완료")
 

--- a/utils.py
+++ b/utils.py
@@ -136,6 +136,13 @@ def setup_dialog_handler(page, auto_accept: bool = True) -> None:
                     pass
                 log(f"⚠️ 로그아웃 관련 다이얼로그 무시: {dialog.message}")
                 return
+            if "차단되었습니다" in dialog.message:
+                try:
+                    dialog.dismiss()
+                except Exception:
+                    pass
+                log("❌ '추가 대화 차단' 다이얼로그 감지")
+                raise RuntimeError("Dialog blocked by browser")
             if auto_accept:
                 dialog.accept()
             else:
@@ -283,7 +290,7 @@ def close_popups(
     closed = 0
     detected = 0
 
-    loops = max(2, repeat)
+    loops = min(max(2, repeat), 10)
     start = time.time() * 1000
     for _ in range(loops):
         loop_closed = 0


### PR DESCRIPTION
## Summary
- detect browser dialog block message and login page during popup handling
- enforce retry limit for popup closing loops
- exit if block message or login page appears

## Testing
- `pip install -r requirements.txt`
- `python -m playwright install` *(fails: domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859050f2a9083209d6233411cd00de9