### PR TITLE
Improve popup handling reliability

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,9 @@ def main() -> None:
             if not close_detected_popups(page):
                 log("❗ 팝업을 모두 닫지 못해 자동화를 중단합니다")
                 return
+            if "차단되었습니다" in page.content():
+                log("❌ 페이지에서 차단 메시지 감지되어 종료합니다")
+                return
             if dialog_blocked(page) or login_page_visible(page):
                 log("❗ 차단 메시지 또는 로그인 페이지 감지되어 종료합니다")
                 return


### PR DESCRIPTION
## Summary
- limit loops in popup close routine
- detect block message inside popup handler
- wait 300 ms between popup passes
- abort execution if block message found after login

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685908ec929c83208007a426c0a89d0e