### PR TITLE
Improve popup handling with dynamic waits

### DIFF
--- a/handlers/popup_handler.py
+++ b/handlers/popup_handler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import time
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 import utils
 
 # 메시지 차단 감지용 선택자 목록
@@ -123,7 +123,7 @@ def handle_text_popups(page: Page) -> None:
                     if btn.is_visible() and btn.is_enabled():
                         try:
                             btn.click(timeout=0, force=True)
-                            frame.wait_for_timeout(300)
+                            expect(btn).not_to_be_visible(timeout=2000)
                             clicked = True
                         except Exception:
                             utils.log(f"텍스트 팝업 닫기 실패: {sel}")
@@ -197,12 +197,11 @@ def close_detected_popups(
                     if btn.is_visible():
                         try:
                             btn.click(timeout=0)
-                            frame.wait_for_timeout(300)
+                            expect(btn).not_to_be_visible(timeout=2000)
                             found = True
                         except Exception as e:
                             utils.log(f"닫기 버튼 클릭 실패: {e}")
         handle_text_popups(page)
-        page.wait_for_timeout(300)
         checks += 1
         loops += 1
         visible = False
@@ -226,7 +225,12 @@ def close_detected_popups(
             utils.popup_handled = True
             utils.log(f"✅ 팝업 처리 완료 ({checks}회 확인)")
             return True
-        page.wait_for_timeout(3000)
+        for sel in selectors:
+            try:
+                page.wait_for_selector(sel, timeout=1000)
+                break
+            except Exception:
+                continue
     utils.popup_handled = False
     utils.log("❌ 팝업 닫기 시간 초과")
     return False

--- a/sales_analysis/extract_sales_detail.py
+++ b/sales_analysis/extract_sales_detail.py
@@ -1,6 +1,6 @@
 import datetime
 from pathlib import Path
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 from utils import popups_handled, log
 
 
@@ -55,7 +55,7 @@ def extract_sales_detail(page: Page) -> Path:
             row = left_rows.nth(i)
             code = row.inner_text().strip()
             row.click()
-            page.wait_for_timeout(500)
+            expect(page.locator("#gdDetail div[class^='gridrow_']")).to_be_visible(timeout=3000)
 
             container = page.locator("div[id*='gdDetail']")
             details = page.locator("#gdDetail div[class^='gridrow_']")

--- a/sales_analysis/middle_category_product_extractor.py
+++ b/sales_analysis/middle_category_product_extractor.py
@@ -1,7 +1,7 @@
 import json
 import datetime
 from pathlib import Path
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 from utils import popups_handled, log
 
 
@@ -29,7 +29,7 @@ def extract_middle_category_products(page: Page) -> Path:
         row = left_rows.nth(i)
         category = row.inner_text().strip()
         row.click()
-        page.wait_for_timeout(500)
+        expect(page.locator("#gdDetail div[class^='gridrow_']")).to_be_visible(timeout=3000)
 
         detail_rows = page.locator("#gdDetail div[class^='gridrow_']")
         products: list[dict] = []

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import sync_playwright, expect
 from utils import (
     inject_init_cleanup_script,
     popups_handled,
@@ -59,7 +59,7 @@ def navigate_sales_ratio(page):
         raise RuntimeError("팝업 처리가 완료되지 않아 메뉴 이동을 중단합니다")
     if not click_sales_analysis_tab(page):
         raise RuntimeError("Cannot find '매출분석' menu")
-    page.wait_for_timeout(1000)
+    expect(page.locator("text=중분류별 매출 구성비")).to_be_visible(timeout=5000)
     if not find_and_click(page, "중분류별 매출 구성비"):
         raise RuntimeError("Cannot find '중분류별 매출 구성비' submenu")
     page.wait_for_load_state("networkidle")


### PR DESCRIPTION
## Summary
- refine popup closing logic to wait for elements to disappear
- ensure menu navigation waits for submenu visibility
- rely on dynamic waits when extracting sales details
- use dynamic waits for middle category product extraction

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591debd41c8320b6d9314dcc13f9ac