### PR TITLE
Add utility for dialog and layer popup handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,8 +25,8 @@ from utils import (
     set_ignore_popup_failure,
     log,
 )
+from popup_handler_utility import setup_dialog_handler, close_layer_popup
 from handlers.popup_handler import (
-    setup_dialog_handler,
     close_detected_popups,
     dialog_blocked,
     login_page_visible,
@@ -110,6 +110,9 @@ def main() -> None:
 
             if wait_after_login:
                 page.wait_for_timeout(wait_after_login * 1000)
+
+            # 특정 레이어 팝업 우선 처리
+            close_layer_popup(page, "#popup", "#popup-close")
 
             log("🟡 팝업 처리 시작")
             if not close_detected_popups(page):

--- a/popup_handler_utility.py
+++ b/popup_handler_utility.py
@@ -1,0 +1,70 @@
+import time
+from playwright.sync_api import Page
+import utils
+from handlers.popup_handler import setup_dialog_handler as _setup_dialog_handler
+
+
+def setup_dialog_handler(page: Page, accept: bool = True) -> None:
+    """Attach a dialog handler that automatically accepts or dismisses dialogs."""
+    _setup_dialog_handler(page, auto_accept=accept)
+
+
+def close_layer_popup(
+    page: Page,
+    popup_selector: str,
+    close_selector: str,
+    *,
+    timeout: int = 5000,
+    check_interval: int = 500,
+) -> bool:
+    """Close a specific layer popup and wait until it disappears.
+
+    Parameters
+    ----------
+    page : Page
+        Playwright page instance.
+    popup_selector : str
+        Selector that identifies the popup container.
+    close_selector : str
+        Selector for the popup close button.
+    timeout : int, optional
+        Maximum waiting time in milliseconds. Default is 5000.
+    check_interval : int, optional
+        Interval between visibility checks in milliseconds. Default is 500.
+
+    Returns
+    -------
+    bool
+        ``True`` if the popup was closed or not visible, ``False`` on timeout
+        or error.
+    """
+    try:
+        start = time.time()
+        layer = page.locator(popup_selector)
+        if layer.count() == 0 or not layer.first.is_visible():
+            return True
+        # Try close button using various selectors
+        selectors = [close_selector, "text=닫기", "button:has-text('닫기')", "a:has-text('닫기')"]
+        clicked = False
+        for sel in selectors:
+            try:
+                btn = page.locator(sel)
+                if btn.count() > 0 and btn.first.is_visible():
+                    btn.first.click()
+                    clicked = True
+                    break
+            except Exception as e:
+                utils.log(f"닫기 버튼 탐색 오류({sel}): {e}")
+        if not clicked:
+            utils.log(f"❌ 닫기 버튼을 찾지 못했습니다: {close_selector}")
+        # Wait until popup disappears
+        while time.time() - start < timeout / 1000:
+            if layer.count() == 0 or not layer.first.is_visible():
+                utils.log("✅ 레이어 팝업 닫힘")
+                return True
+            page.wait_for_timeout(check_interval)
+        utils.log("❌ 레이어 팝업 닫기 시간 초과")
+        return False
+    except Exception as e:  # pragma: no cover - logging only
+        utils.log(f"레이어 팝업 처리 오류: {e}")
+        return False


### PR DESCRIPTION
## Summary
- provide `popup_handler_utility` module with helpers for dialog and layer popup management
- integrate new utility in `main.py` and demonstrate closing a layer popup before general popup processing

## Testing
- `python -m py_compile popup_handler_utility.py main.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859ec30cc6083209eb144cdb56462b1