### PR TITLE
Add project root path insertion for direct script execution

### DIFF
--- a/run/codex_runner.py
+++ b/run/codex_runner.py
@@ -1,5 +1,11 @@
 import json
 import os
+import sys
+
+# Add project root to ``sys.path`` so the script works from any location.
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 from playwright.sync_api import sync_playwright
 from utils import (
     inject_init_cleanup_script,

--- a/run/main.py
+++ b/run/main.py
@@ -6,6 +6,12 @@ import glob
 import subprocess
 import sys
 import datetime
+
+# Add project root to ``sys.path`` so modules are importable when running the
+# script from any location.
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 from dotenv import load_dotenv
 from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
 from sales_analysis.extract_sales_detail import extract_sales_detail


### PR DESCRIPTION
## Summary
- make run scripts runnable from any path by adding project root to `sys.path`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a03a53ef08320bc1b12d5acc6f20f