### PR TITLE
Fix login success detection and enforce popup workflow

### DIFF
--- a/run/main.py
+++ b/run/main.py
@@ -115,8 +115,10 @@ def main() -> None:
             page.locator(login_keyword).click()
 
             page.wait_for_load_state("networkidle")
-            if "login" in page.url or login_page_visible(page):
-                log("❌ 로그인 실패로 판단. 팝업 처리 생략 및 자동화 종료")
+            if not ("login" in page.url) and page.locator("#topMenu").is_visible():
+                log("✅ 로그인 성공")
+            else:
+                log("❌ 로그인 실패로 판단. 자동화 종료")
                 return
 
             if wait_after_login:


### PR DESCRIPTION
## Summary
- improve logic to detect login success by checking the `#topMenu` element
- keep using environment credentials and close popups before moving on

## Testing
- `python -m py_compile run/main.py sales_analysis/navigate_sales_ratio.py utils/common.py browser/popup_handler.py browser/popup_handler_utility.py`

------
https://chatgpt.com/codex/tasks/task_e_685a0773513083209b38248f73b7aa94