### PR TITLE
Implement event based popup handling

### DIFF
--- a/run/main.py
+++ b/run/main.py
@@ -32,9 +32,12 @@ from utils import (
     set_ignore_popup_failure,
     log,
 )
-from browser.popup_handler_utility import setup_dialog_handler, close_layer_popup
+from browser.popup_handler_utility import (
+    setup_dialog_handler,
+    close_layer_popup,
+    close_all_popups_event,
+)
 from browser.popup_handler import (
-    close_detected_popups,
     dialog_blocked,
     login_page_visible,
 )
@@ -128,7 +131,7 @@ def main() -> None:
             close_layer_popup(page, "#popup", "#popup-close")
 
             log("🟡 팝업 처리 시작")
-            if not close_detected_popups(page):
+            if not close_all_popups_event(page):
                 log("❗ 팝업을 모두 닫지 못해 자동화를 중단합니다")
                 return
             if "차단되었습니다" in page.content():

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -9,10 +9,8 @@ from utils import (
     popups_handled,
     log,
 )
-from browser.popup_handler import (
-    setup_dialog_handler,
-    close_detected_popups,
-)
+from browser.popup_handler import setup_dialog_handler
+from browser.popup_handler_utility import close_all_popups_event
 
 
 def click_sales_analysis_tab(page) -> bool:
@@ -101,7 +99,7 @@ def run():
                 page.wait_for_timeout(wait_after_login * 1000)
 
             if not popups_handled():
-                if not close_detected_popups(page):
+                if not close_all_popups_event(page):
                     log("❗ 팝업을 모두 닫지 못해 작업을 중단합니다")
                     return
 


### PR DESCRIPTION
## Summary
- improve popup utilities to use Playwright events
- add screenshot logging on popup failures
- rely on new `close_all_popups_event` in main automation flow
- update sales navigation module to use the new popup handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a140c10d4832085faac07984f32f1