### PR TITLE
Refactor popup flow and modularize scripts

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,37 @@
+import os
+from dotenv import load_dotenv
+from playwright.sync_api import Page
+from utils import log
+from browser.popup_handler_utility import close_layer_popup, setup_dialog_handler
+
+load_dotenv()
+
+URL = "https://store.bgfretail.com/websrc/deploy/index.html"
+
+
+def perform_login(page: Page, structure: dict) -> bool:
+    """Login using credentials from .env and given page structure."""
+    user_id = os.getenv("LOGIN_ID")
+    user_pw = os.getenv("LOGIN_PW")
+    if not user_id or not user_pw:
+        log("❗ LOGIN_ID 또는 LOGIN_PW가 설정되지 않았습니다")
+        return False
+
+    log("➡️ 로그인 페이지 접속")
+    page.goto(URL)
+    page.locator(structure["id"]).click()
+    page.keyboard.type(user_id)
+    page.locator(structure["password"]).click()
+    page.keyboard.type(user_pw)
+    page.locator(structure["login_button"]).click()
+    page.wait_for_load_state("networkidle")
+
+    if "login" in page.url or not page.locator("#topMenu").is_visible():
+        log("❌ 로그인 실패")
+        return False
+
+    log("✅ 로그인 성공")
+    setup_dialog_handler(page)
+    # 선제적으로 알려진 레이어 팝업 처리
+    close_layer_popup(page, "#popup", "#popup-close")
+    return True

--- a/browser/popup_handler_utility.py
+++ b/browser/popup_handler_utility.py
@@ -153,3 +153,19 @@ def close_layer_popup(
         except Exception:
             pass
         return False
+
+from .popup_handler import close_detected_popups
+
+def close_all_popups(page: Page, loops: int = 3) -> bool:
+    """Unified popup closing routine."""
+    success = close_all_popups_event(page, loops=loops)
+    if not success:
+        success = close_detected_popups(page, loops=loops)
+    if not success:
+        try:
+            ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            page.screenshot(path=f"popup_fail_{ts}.png")
+        except Exception:
+            pass
+        utils.log("❌ 팝업 처리 실패")
+    return success

--- a/order.py
+++ b/order.py
@@ -1,0 +1,22 @@
+import datetime
+from playwright.sync_api import Page
+from utils import log
+from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
+from sales_analysis.extract_sales_detail import extract_sales_detail
+from sales_analysis.middle_category_product_extractor import extract_middle_category_products
+
+
+def run_sales_analysis(page: Page) -> None:
+    """Run sales analysis workflow on Mondays."""
+    if datetime.datetime.today().weekday() != 0:
+        log("오늘은 월요일이 아니므로 매출 분석을 건너뜁니다")
+        return
+
+    log("➡️ 매출분석 메뉴 진입 시도")
+    navigate_sales_ratio(page)
+    log("✅ 메뉴 진입 성공")
+
+    log("🟡 매출 상세 데이터 추출 시작")
+    extract_sales_detail(page)
+    extract_middle_category_products(page)
+    log("✅ 매출 상세 데이터 추출 완료")

--- a/utils/common.py
+++ b/utils/common.py
@@ -432,3 +432,24 @@ def process_popups_once(page: Page, *, force: bool = False) -> bool:
     result = handle_popup(page)
     _processed_popups = True
     return result
+
+from pathlib import Path
+
+def update_instruction_state(step: str, failure: str | None = None) -> None:
+    """Update progress status in codex_instruction.txt."""
+    instr_path = Path(__file__).resolve().parent.parent / "instructions" / "codex_instruction.txt"
+    if not instr_path.exists():
+        return
+    try:
+        lines = instr_path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return
+    new_lines = []
+    for line in lines:
+        if line.startswith("진행단계"):
+            new_lines.append(f"진행단계 = {step}")
+        elif line.startswith("마지막실패") and failure is not None:
+            new_lines.append(f"마지막실패 = {failure}")
+        else:
+            new_lines.append(line)
+    instr_path.write_text("\n".join(new_lines), encoding="utf-8")


### PR DESCRIPTION
## Summary
- create `auth.py` for login flow
- add `order.py` for sales analysis logic
- centralize popup control in `popup_handler_utility.close_all_popups`
- orchestrate workflow in `run/main.py`
- allow status reporting to instruction file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a169f0ed48320a73339f7e5fb2f7d