### PR TITLE
Improve login checks and logging

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -14,10 +14,11 @@ def perform_login(page: Page, structure: dict) -> bool:
     user_id = os.getenv("LOGIN_ID")
     user_pw = os.getenv("LOGIN_PW")
     if not user_id or not user_pw:
-        log("❗ LOGIN_ID 또는 LOGIN_PW가 설정되지 않았습니다")
+        log("❗ LOGIN_ID 또는 LOGIN_PW가 설정되지 않았습니다", stage="로그인")
         return False
 
-    log("➡️ 로그인 페이지 접속")
+    log("➡️ perform_login() 진입", stage="로그인 단계")
+    log("로그인 페이지 접속", stage="로그인")
     page.goto(URL)
     page.locator(structure["id"]).click()
     page.keyboard.type(user_id)

--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -55,7 +55,8 @@ def dialog_blocked(page: Page) -> bool:
 def is_logged_in(page: Page) -> bool:
     """Return ``True`` if the main menu after login is visible."""
     try:
-        return page.locator("#topMenu").is_visible(timeout=3000)
+        page.wait_for_selector("#topMenu", timeout=5000)
+        return True
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary
- enhance login detection with waiting
- strengthen logging with context and screenshot captures
- enforce wait for `#topMenu` after closing popups
- add stage logging in `perform_login`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a1fa43e648320bd5cb5da706efe0a