### PR TITLE
Fix login popup handling

### DIFF
--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -30,6 +30,13 @@ POPUP_DEFINITIONS = [
             "#mainframe\\.HFrameSet00\\.VFrameSet00\\.FrameSet\\.WorkFrame\\.STZZ120_P0\\.form\\.btn_close:icontext",
         ],
     },
+    {
+        "name": "재택 안내 팝업",
+        "container_selector": "#popupDiv",
+        "close_selectors": [
+            "button:has-text('닫기')",
+        ],
+    },
 ]
 
 # 메시지 차단 감지용 선택자 목록


### PR DESCRIPTION
## Summary
- close the work-from-home alert layer popup during login
- wait for menu after closing all popups
- register definition for new popup in handler

## Testing
- `pip install -r requirements.txt`
- `python -m playwright install --with-deps` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685a269e4bac83208e0083320faef8b6