### PR TITLE
Improve popup closing with overlay handling

### DIFF
--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -5,6 +5,7 @@ import time
 from typing import Iterable
 
 from playwright.sync_api import Page, expect
+from .popup_handler_utility import remove_overlay
 
 import utils
 
@@ -274,6 +275,7 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
 
     for _ in range(max(2, loops)):
         found = False
+        remove_overlay(page)
         for frame in [page, *page.frames]:
             if hasattr(frame, "is_detached") and frame.is_detached():
                 continue
@@ -301,6 +303,7 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
                             page.screenshot(path=f"popup_error_{ts}.png")
                         except Exception:
                             pass
+                        remove_overlay(page)
         if not found:
             break
         handle_text_popups(page)


### PR DESCRIPTION
## Summary
- add `remove_overlay` utility to wait for and remove blocking overlays
- integrate overlay waiting into popup closing helpers

## Testing
- `python -m py_compile browser/popup_handler.py browser/popup_handler_utility.py utils/common.py order.py run/main.py sales_analysis/navigate_sales_ratio.py sales_analysis/extract_sales_detail.py sales_analysis/middle_category_product_extractor.py sales_analysis/sales_ratio_detail_extractor.py auth.py`

------
https://chatgpt.com/codex/tasks/task_e_685a2cb3a9388320a876a2e336955fc2