### PR TITLE
Improve overlay handling logic

### DIFF
--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -294,7 +294,11 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
 
     for _ in range(max(2, loops)):
         found = False
-        remove_overlay(page)
+        try:
+            if not page.locator("#topMenu").is_visible(timeout=1000):
+                remove_overlay(page)
+        except Exception:
+            remove_overlay(page)
         for frame in [page, *page.frames]:
             if hasattr(frame, "is_detached") and frame.is_detached():
                 continue
@@ -322,7 +326,7 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
                             page.screenshot(path=f"popup_error_{ts}.png")
                         except Exception:
                             pass
-                        remove_overlay(page)
+                        remove_overlay(page, force=True)
         if not found:
             break
         handle_text_popups(page)

--- a/browser/popup_handler_utility.py
+++ b/browser/popup_handler_utility.py
@@ -37,7 +37,11 @@ def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 500) -> bo
 
     for _ in range(max(2, loops)):
         found = False
-        remove_overlay(page)
+        try:
+            if not page.locator("#topMenu").is_visible(timeout=1000):
+                remove_overlay(page)
+        except Exception:
+            remove_overlay(page)
         for sel in selectors:
             try:
                 locs = page.locator(sel)
@@ -62,7 +66,7 @@ def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 500) -> bo
                         page.screenshot(path=f"popup_error_{ts}.png")
                     except Exception:
                         pass
-                    remove_overlay(page)
+                    remove_overlay(page, force=True)
         close_popup_windows(page, timeout=500)
         if not found:
             break
@@ -113,7 +117,11 @@ def close_layer_popup(
         if layer.count() == 0 or not layer.first.is_visible():
             return True
 
-        remove_overlay(page)
+        try:
+            if not page.locator("#topMenu").is_visible(timeout=1000):
+                remove_overlay(page)
+        except Exception:
+            remove_overlay(page)
 
         selectors = [
             close_selector,

--- a/browser/popup_utils.py
+++ b/browser/popup_utils.py
@@ -1,8 +1,21 @@
 # Utility functions for popup handling
 from playwright.sync_api import Page
+from utils import log
 
 
-def remove_overlay(page: Page) -> None:
-    """Remove blocking overlay if present."""
-    page.evaluate("document.getElementById('nexacontainer')?.remove()")
+def remove_overlay(page: Page, *, force: bool = False) -> None:
+    """Wait for overlay to disappear and optionally remove it as a last resort."""
+
+    try:
+        overlay = page.locator("#nexacontainer")
+        overlay.wait_for(state="hidden", timeout=5000)
+    except Exception:
+        log("⚠️ 오버레이가 사라지지 않음 - remove()는 사용하지 않음")
+        if force:
+            try:
+                if not page.locator("#topMenu").is_visible(timeout=3000):
+                    page.evaluate("document.getElementById('nexacontainer')?.remove()")
+                    log("🛠️ 오버레이 강제 제거 수행됨")
+            except Exception:
+                log("❌ 오버레이 강제 제거 실패")
 


### PR DESCRIPTION
## Summary
- make overlay removal wait for hidden state first
- conditionally call overlay removal in popup handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a35c413448320871d06e847f197bc