### PR TITLE
Add text-based popup handler

### DIFF
--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -6,6 +6,7 @@ from typing import Iterable
 
 from playwright.sync_api import Page, expect
 from .popup_utils import remove_overlay
+from popup_text_handler import handle_popup_by_text
 
 import utils
 
@@ -294,11 +295,10 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
 
     for _ in range(max(2, loops)):
         found = False
-        try:
-            if not page.locator("#topMenu").is_visible(timeout=1000):
-                remove_overlay(page)
-        except Exception:
-            remove_overlay(page)
+        if handle_popup_by_text(page):
+            found = True
+            time.sleep(wait_ms / 1000)
+            continue
         for frame in [page, *page.frames]:
             if hasattr(frame, "is_detached") and frame.is_detached():
                 continue

--- a/popup_text_handler.py
+++ b/popup_text_handler.py
@@ -1,0 +1,41 @@
+from playwright.sync_api import Page
+from utils import log
+
+POPUP_RULES = [
+    {
+        "contains": ["재택 유선권장 안내"],
+        "selector": "div[id$='btn_close:icontext']",
+        "action": lambda page, sel: page.click(sel),
+    },
+    {
+        "contains": ["비밀번호를 입력"],
+        "selector": "dialog",
+        "action": lambda page, sel: page.on("dialog", lambda d: d.accept()),
+    },
+    {
+        "contains": ["세션이 만료"],
+        "selector": "body",
+        "action": lambda page, sel: page.reload(),
+    },
+]
+
+
+def handle_popup_by_text(page: Page) -> bool:
+    try:
+        popup_title = page.locator("div[id$='Static00:text']").inner_text(timeout=1000)
+    except Exception:
+        log("팝업 제목 탐지 실패")
+        return False
+
+    for rule in POPUP_RULES:
+        if any(keyword in popup_title for keyword in rule["contains"]):
+            log(f"📌 팝업 탐지됨: '{popup_title}' → 규칙 적용")
+            try:
+                rule["action"](page, rule["selector"])
+                return True
+            except Exception as e:
+                log(f"❌ 팝업 닫기 실패: {e}")
+                return False
+
+    log(f"⚠️ 팝업 규칙 없음: '{popup_title}'")
+    return False


### PR DESCRIPTION
## Summary
- introduce `popup_text_handler.py` for rule-based popup processing
- integrate new handler into popup utilities
- stop auto overlay removal in normal popup handling

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a38e0da8483208daf84cd3134857b