### PR TITLE
Refactor popup handling to use text-based rules

### DIFF
--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -2,44 +2,11 @@ from __future__ import annotations
 
 import datetime
 import time
-from typing import Iterable
-
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page
 from .popup_utils import remove_overlay
 from popup_text_handler import handle_popup_by_text
 
 import utils
-
-# 구조화된 팝업 정의 목록
-POPUP_DEFINITIONS = [
-    {
-        "name": "Generic Popup",
-        "container_selector": "div[style*='z-index']",
-        "close_selectors": [
-            "text=닫기",
-            "button:has-text('닫기')",
-            "a:has-text('닫기')",
-            "[class*='close']",
-            "[id*='close']",
-            "button:has-text('✕')",
-            "text=✕",
-        ],
-    },
-    {
-        "name": "STZZ120",
-        "container_selector": "div[id*='STZZ120_P0']",
-        "close_selectors": [
-            "#mainframe\\.HFrameSet00\\.VFrameSet00\\.FrameSet\\.WorkFrame\\.STZZ120_P0\\.form\\.btn_close:icontext",
-        ],
-    },
-    {
-        "name": "재택 안내 팝업",
-        "container_selector": "#popupDiv",
-        "close_selectors": [
-            "button:has-text('닫기')",
-        ],
-    },
-]
 
 # 메시지 차단 감지용 선택자 목록
 BLOCK_SELECTORS = [
@@ -91,96 +58,6 @@ def is_logged_in(page: Page) -> bool:
         return True
 
 
-def login_page_visible(page: Page) -> bool:
-    """Return ``True`` if the login form is still visible."""
-    try:
-        return page.locator("#loginForm").is_visible(timeout=1000)
-    except Exception:
-        return False
-
-
-def _locators_iter(frame: Page, selectors: Iterable[str]):
-    """Yield locators for each selector, ignoring errors."""
-    for sel in selectors:
-        try:
-            loc = frame.locator(sel)
-        except Exception:
-            continue
-        if loc.count() > 0:
-            yield sel, loc
-
-
-def close_all_popups(page: Page, *, max_loops: int = 5, wait_ms: int = 500) -> bool:
-    """Close all popups defined in ``POPUP_DEFINITIONS`` until none remain."""
-
-    max_loops = max(2, max_loops)
-    loops = 0
-    closed_any = False
-    while loops < max_loops:
-        loops += 1
-        found = False
-        for definition in POPUP_DEFINITIONS:
-            name = definition["name"]
-            container_sel = definition["container_selector"]
-            close_sels = definition["close_selectors"]
-            for frame in [page, *page.frames]:
-                try:
-                    containers = frame.locator(container_sel)
-                except Exception:
-                    continue
-                for i in range(containers.count()):
-                    cont = containers.nth(i)
-                    if not cont.is_visible():
-                        continue
-                    utils.log(f"팝업 감지 → {name}")
-                    clicked = False
-                    for sel in close_sels:
-                        loc = cont.locator(sel)
-                        if loc.count() == 0:
-                            loc = frame.locator(sel)
-                        for _, btn in (
-                            (idx, loc.nth(idx)) for idx in range(loc.count())
-                        ):
-                            if btn.is_visible():
-                                try:
-                                    btn.click(timeout=0)
-                                    utils.log(f"'{name}' 팝업 닫기: {sel}")
-                                    closed_any = True
-                                    clicked = True
-                                    break
-                                except Exception as e:
-                                    utils.log(f"'{name}' 팝업 닫기 실패({sel}): {e}")
-                        if clicked:
-                            break
-                    if clicked:
-                        found = True
-                        break
-                if found:
-                    break
-            if found:
-                break
-        if not found:
-            visible = False
-            for definition in POPUP_DEFINITIONS:
-                sel = definition["container_selector"]
-                for frame in [page, *page.frames]:
-                    try:
-                        loc = frame.locator(sel)
-                    except Exception:
-                        continue
-                    for j in range(loc.count()):
-                        if loc.nth(j).is_visible():
-                            visible = True
-                            break
-                    if visible:
-                        break
-                if visible:
-                    break
-            if not visible:
-                break
-        page.wait_for_timeout(wait_ms)
-    return closed_any
-
 
 def setup_dialog_handler(page: Page, auto_accept: bool = True) -> None:
     """Register a dialog handler that auto processes common dialogs."""
@@ -216,69 +93,6 @@ def setup_dialog_handler(page: Page, auto_accept: bool = True) -> None:
     page.on("dialog", _handle)
 
 
-def handle_text_popups(page: Page) -> None:
-    """Click common text-based confirmation buttons in all frames."""
-    texts = ["확인", "확인하기"]
-    logout_keywords = ["종료 하시겠습니까", "로그아웃", "세션 종료"]
-    selectors = (
-        [f"div:has-text('{t}')" for t in texts]
-        + [f"button:has-text('{t}')" for t in texts]
-        + [f"div[class*='nexacontentsbox']:has-text('{t}')" for t in texts]
-        + [f"div[id*='btn_enter']:has-text('{t}')" for t in texts]
-        + [
-            "div[class*='nexacontentsbox']:has-text('확인하기')",
-            "div[id*='btn_enter']:has-text('확인')",
-        ]
-    )
-
-    # 로그아웃 유도 팝업 감지 시 자동 클릭 중단
-    for frame in [page, *page.frames]:
-        for kw in logout_keywords:
-            try:
-                warning = frame.locator(
-                    f"div[class*='nexacontentsbox']:has-text('{kw}')"
-                )
-                if warning.count() > 0 and warning.first.is_visible():
-                    utils.log(f"⚠️ 로그아웃 관련 팝업 감지: {kw}")
-                    return
-            except Exception:
-                continue
-
-    for _ in range(2):
-        clicked = False
-        for frame in [page, *page.frames]:
-            if hasattr(frame, "is_detached") and frame.is_detached():
-                continue
-            for sel in selectors:
-                try:
-                    loc = frame.locator(sel)
-                except Exception:
-                    continue
-                count = loc.count()
-                if count == 0:
-                    print("감지된 수:", count)
-                for i in range(count):
-                    btn = loc.nth(i)
-                    try:
-                        text = btn.inner_text()
-                        btn_id = btn.get_attribute("id") or ""
-                        btn_class = btn.get_attribute("class") or ""
-                        utils.log(
-                            f"팝업 버튼 감지 → text:'{text}', id:'{btn_id}', class:'{btn_class}', sel:'{sel}'"
-                        )
-                    except Exception:
-                        text = ""
-                    if btn.is_visible() and btn.is_enabled():
-                        try:
-                            btn.click(timeout=0, force=True)
-                            expect(btn).not_to_be_visible(timeout=2000)
-                            clicked = True
-                        except Exception:
-                            utils.log(f"텍스트 팝업 닫기 실패: {sel}")
-                    else:
-                        print("텍스트:", text)
-        if not clicked:
-            break
 
 
 def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> bool:
@@ -293,10 +107,13 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
         "text=✕",
     ]
 
-    for _ in range(max(2, loops)):
+    loops = max(2, loops)
+    closed_any = False
+    for _ in range(loops):
         found = False
         if handle_popup_by_text(page):
             found = True
+            closed_any = True
             time.sleep(wait_ms / 1000)
             continue
         for frame in [page, *page.frames]:
@@ -319,18 +136,15 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
                         if pop.value:
                             pop.value.close()
                         found = True
-                    except Exception as e:
-                        utils.log(f"닫기 버튼 클릭 실패: {e}")
-                        try:
-                            ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-                            page.screenshot(path=f"popup_error_{ts}.png")
-                        except Exception:
-                            pass
-                        remove_overlay(page, force=True)
+                        closed_any = True
+                    except Exception:
+                        continue
         if not found:
             break
-        handle_text_popups(page)
         time.sleep(wait_ms / 1000)
+
+    if not closed_any:
+        remove_overlay(page, force=True)
 
     for frame in [page, *page.frames]:
         for sel in selectors:
@@ -343,5 +157,6 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
                     utils.popup_handled = False
                     return False
     utils.popup_handled = True
-    utils.log("✅ 팝업 처리 완료")
-    return True
+    if closed_any:
+        utils.log("✅ 팝업 처리 완료")
+    return closed_any

--- a/browser/popup_handler_utility.py
+++ b/browser/popup_handler_utility.py
@@ -1,4 +1,3 @@
-import time
 import datetime
 from playwright.sync_api import Page, TimeoutError
 import utils
@@ -13,16 +12,7 @@ def setup_dialog_handler(page: Page, accept: bool = True) -> None:
     _setup_dialog_handler(page, auto_accept=accept)
 
 
-def close_popup_windows(page: Page, timeout: int = 1000) -> None:
-    """Close popup windows spawned from the current page."""
-    while True:
-        try:
-            popup = page.wait_for_event("popup", timeout=timeout).value
-            popup.wait_for_load_state()
-            popup.close()
-            utils.log("새 창 팝업 닫힘")
-        except TimeoutError:
-            break
+
 
 
 def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 500) -> bool:
@@ -61,8 +51,6 @@ def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 500) -> bo
                         page.screenshot(path=f"popup_error_{ts}.png")
                     except Exception:
                         pass
-                    remove_overlay(page, force=True)
-        close_popup_windows(page, timeout=500)
         if not found:
             break
         page.wait_for_timeout(wait_ms)
@@ -169,6 +157,7 @@ def close_all_popups(page: Page, loops: int = 3) -> bool:
         success = True
     else:
         utils.log("➡️ 규칙 외 팝업 처리 fallback 진행")
+        remove_overlay(page, force=True)
         success = close_all_popups_event(page, loops=loops)
         if not success:
             success = close_detected_popups(page, loops=loops)

--- a/run/codex_runner.py
+++ b/run/codex_runner.py
@@ -11,10 +11,8 @@ from utils import (
     inject_init_cleanup_script,
     popups_handled,
 )
-from browser.popup_handler import (
-    setup_dialog_handler,
-    close_detected_popups,
-)
+from browser.popup_handler import setup_dialog_handler
+from browser.popup_handler_utility import close_all_popups
 from dotenv import load_dotenv
 
 # Load environment variables from .env
@@ -70,7 +68,7 @@ def run() -> None:
                 page.wait_for_timeout(wait_after_login * 1000)
 
             if not popups_handled():
-                if not close_detected_popups(page):
+                if not close_all_popups(page):
                     print("⚠️ 일부 팝업이 닫히지 않았으나 계속 진행합니다")
                 else:
                     print("✅ 모든 팝업 처리 완료")


### PR DESCRIPTION
## Summary
- simplify `popup_handler.py` to rely on `handle_popup_by_text`
- strip overlay removal from normal flows in `popup_handler_utility`
- update codex runner to use the unified `close_all_popups` API

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685a3a9db65083208a34f9487abbdcbd