### PR TITLE
Improve popup handling rules

### DIFF
--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -103,6 +103,7 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
         "a:has-text('닫기')",
         "[class*='close']",
         "[id*='close']",
+        "div[id*='btn_close']",
         "button:has-text('✕')",
         "text=✕",
     ]
@@ -144,6 +145,26 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
         time.sleep(wait_ms / 1000)
 
     if not closed_any:
+        # 팝업 버튼 탐색 실패 시 추가로 div/button 검색 시도
+        alt_selectors = ["div[id*='btn_close']", "div:has-text('닫기')", "button:has-text('닫기')"]
+        for sel in alt_selectors:
+            try:
+                locs = page.locator(sel)
+            except Exception:
+                continue
+            for i in range(locs.count()):
+                btn = locs.nth(i)
+                if btn.is_visible():
+                    try:
+                        btn.click(timeout=0)
+                        closed_any = True
+                        break
+                    except Exception:
+                        continue
+            if closed_any:
+                break
+
+    if closed_any:
         remove_overlay(page, force=True)
 
     for frame in [page, *page.frames]:

--- a/browser/popup_handler_utility.py
+++ b/browser/popup_handler_utility.py
@@ -157,10 +157,11 @@ def close_all_popups(page: Page, loops: int = 3) -> bool:
         success = True
     else:
         utils.log("➡️ 규칙 외 팝업 처리 fallback 진행")
-        remove_overlay(page, force=True)
         success = close_all_popups_event(page, loops=loops)
         if not success:
             success = close_detected_popups(page, loops=loops)
+    if success:
+        remove_overlay(page, force=True)
     if not success:
         try:
             ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/popup_text_handler.py
+++ b/popup_text_handler.py
@@ -19,12 +19,18 @@ POPUP_RULES = [
     },
 ]
 
+EXCLUDE_TEXTS = ["Copyright", "BGF Retail"]
+
 
 def handle_popup_by_text(page: Page) -> bool:
     try:
         popup_title = page.locator("div[id$='Static00:text']").inner_text(timeout=1000)
     except Exception:
         log("팝업 제목 탐지 실패")
+        return False
+
+    if any(ex in popup_title for ex in EXCLUDE_TEXTS):
+        log("⏩ 제외 팝업으로 판단 - 무시")
         return False
 
     for rule in POPUP_RULES:


### PR DESCRIPTION
## Summary
- add exclusions for BGF Retail copyright notification
- refine popup detection fallback logic with additional selectors
- avoid overlay removal unless at least one popup button was clicked
- only call overlay removal after successful popup handling

## Testing
- `python -m py_compile popup_text_handler.py browser/popup_handler.py browser/popup_handler_utility.py`

------
https://chatgpt.com/codex/tasks/task_e_685a3dfd21f083209629833155e78250