### PR TITLE
Implement 1 second wait rule and popup workflow

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
 from playwright.sync_api import Page
-from utils import log, handle_exception
+from utils import log, handle_exception, wait
 from browser.popup_handler_utility import (
     close_layer_popup,
     close_all_popups,
@@ -23,7 +23,9 @@ def perform_login(page: Page, structure: dict) -> bool:
 
     try:
         log("[로그인] 페이지 이동")
+        wait(page)
         page.goto(URL)
+        wait(page)
 
         # Wait for both input fields to be ready
         page.wait_for_selector(structure["id"])
@@ -33,21 +35,30 @@ def perform_login(page: Page, structure: dict) -> bool:
         pw_input = page.locator(structure["password"])
 
         log("[로그인] 아이디 입력")
+        wait(page)
         id_input.click()
+        wait(page)
         id_input.fill(user_id)
+        wait(page)
 
         log("[로그인] 비밀번호 입력")
+        wait(page)
         pw_input.click()
+        wait(page)
         pw_input.fill(user_pw)
+        wait(page)
 
         # Small delay before clicking the login button
-        page.wait_for_timeout(500)
+        wait(page)
 
         login_btn = page.locator(structure["login_button"])
         log("[로그인] 로그인 버튼 클릭")
+        wait(page)
         login_btn.click()
+        wait(page)
 
         # 로그인 직후 등장하는 재택 안내 팝업 우선 처리
+        wait(page)
         close_layer_popup(
             page,
             popup_selector="#popupDiv",
@@ -55,10 +66,13 @@ def perform_login(page: Page, structure: dict) -> bool:
             timeout=3000,
         )
         # 기존 팝업도 추가로 처리
+        wait(page)
         close_layer_popup(page, "#popup", "#popup-close")
 
         # 모든 팝업이 닫힐 때까지 반복적으로 탐색
+        wait(page)
         close_all_popups(page)
+        wait(page)
 
         # 로딩 진행 표시가 사라질 때까지 대기
         try:

--- a/browser/popup_handler_utility.py
+++ b/browser/popup_handler_utility.py
@@ -14,7 +14,7 @@ def setup_dialog_handler(page: Page, accept: bool = True) -> None:
 
 
 
-def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 500) -> bool:
+def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 1000) -> bool:
     """Search and close popups using event based waits."""
     selectors = [
         "text=닫기",

--- a/order.py
+++ b/order.py
@@ -1,6 +1,6 @@
 import datetime
 from playwright.sync_api import Page
-from utils import log
+from utils import log, wait
 from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
 from sales_analysis.extract_sales_detail import extract_sales_detail
 from sales_analysis.middle_category_product_extractor import extract_middle_category_products
@@ -13,10 +13,15 @@ def run_sales_analysis(page: Page) -> None:
         return
 
     log("➡️ 매출분석 메뉴 진입 시도")
+    wait(page)
     navigate_sales_ratio(page)
+    wait(page)
     log("✅ 메뉴 진입 성공")
 
     log("🟡 매출 상세 데이터 추출 시작")
+    wait(page)
     extract_sales_detail(page)
+    wait(page)
     extract_middle_category_products(page)
+    wait(page)
     log("✅ 매출 상세 데이터 추출 완료")

--- a/run/main.py
+++ b/run/main.py
@@ -25,6 +25,7 @@ from utils import (
     set_ignore_popup_failure,
     update_instruction_state,
     handle_exception,
+    wait,
 )
 
 load_dotenv()
@@ -81,10 +82,14 @@ def main() -> None:
                 update_instruction_state("종료", "로그인 실패")
                 return
 
+            wait(page)
+
             update_instruction_state("팝업 처리 중")
             log("close_all_popups() 호출", stage="팝업 처리")
+            wait(page)
             try:
                 popup_closed = close_all_popups(page)
+                wait(page)
                 if not popup_closed:
                     popup_fail_count += 1
                     log("❌ 팝업 닫기 실패", stage="팝업 처리")
@@ -114,6 +119,7 @@ def main() -> None:
                             break
                     if alt_found and close_all_popups(page):
                         popup_closed = True
+                        wait(page)
                     if not popup_closed:
                         # 메뉴 탐색 재시도
                         menu_found = False

--- a/sales_analysis/extract_sales_detail.py
+++ b/sales_analysis/extract_sales_detail.py
@@ -1,7 +1,7 @@
 import datetime
 from pathlib import Path
 from playwright.sync_api import Page, expect
-from utils import popups_handled, log
+from utils import popups_handled, log, wait
 
 
 def set_month_date_range(page: Page) -> tuple[str, str]:
@@ -13,15 +13,23 @@ def set_month_date_range(page: Page) -> tuple[str, str]:
 
     start_input = page.locator("input[id$='calFromDay.calendaredit:input']")
     if start_input.count() > 0:
+        wait(page)
         start_input.click()
+        wait(page)
         start_input.fill(start_str)
+        wait(page)
         start_input.press("Enter")
+        wait(page)
 
     end_input = page.locator("input[id$='calToDay.calendaredit:input']")
     if end_input.count() > 0:
+        wait(page)
         end_input.click()
+        wait(page)
         end_input.fill(end_str)
+        wait(page)
         end_input.press("Enter")
+        wait(page)
 
     return start_str, end_str
 
@@ -36,8 +44,11 @@ def extract_sales_detail(page: Page) -> Path:
 
     search_btn = page.locator("div.nexacontentsbox:has-text('조 회')")
     if search_btn.count() > 0:
+        wait(page)
         search_btn.first.click()
+        wait(page)
         page.wait_for_load_state("networkidle")
+        wait(page)
     else:
         log("⚠️ 조회 버튼을 찾을 수 없습니다")
 
@@ -54,7 +65,9 @@ def extract_sales_detail(page: Page) -> Path:
         for i in range(row_count):
             row = left_rows.nth(i)
             code = row.inner_text().strip()
+            wait(page)
             row.click()
+            wait(page)
             expect(page.locator("#gdDetail div[class^='gridrow_']")).to_be_visible(timeout=3000)
 
             container = page.locator("div[id*='gdDetail']")
@@ -72,6 +85,7 @@ def extract_sales_detail(page: Page) -> Path:
                 if text:
                     f.write(text + "\n")
             f.write("\n")
+            wait(page)
 
     if total_details > 0:
         log(f"✅ 매출상세 데이터 저장 → {out_path}")

--- a/sales_analysis/middle_category_product_extractor.py
+++ b/sales_analysis/middle_category_product_extractor.py
@@ -2,7 +2,7 @@ import json
 import datetime
 from pathlib import Path
 from playwright.sync_api import Page, expect
-from utils import popups_handled, log
+from utils import popups_handled, log, wait
 
 
 def extract_middle_category_products(page: Page) -> Path:
@@ -28,7 +28,9 @@ def extract_middle_category_products(page: Page) -> Path:
     for i in range(row_count):
         row = left_rows.nth(i)
         category = row.inner_text().strip()
+        wait(page)
         row.click()
+        wait(page)
         expect(page.locator("#gdDetail div[class^='gridrow_']")).to_be_visible(timeout=3000)
 
         detail_rows = page.locator("#gdDetail div[class^='gridrow_']")
@@ -48,6 +50,7 @@ def extract_middle_category_products(page: Page) -> Path:
     out_path = output_dir / file_name
     with out_path.open("w", encoding="utf-8") as f:
         json.dump(result, f, ensure_ascii=False, indent=2)
+        wait(page)
 
     log(f"✅ 상품코드 및 상품명 저장 → {out_path}")
     return out_path

--- a/sales_analysis/navigate_sales_ratio.py
+++ b/sales_analysis/navigate_sales_ratio.py
@@ -8,6 +8,7 @@ from utils import (
     inject_init_cleanup_script,
     popups_handled,
     log,
+    wait,
 )
 from browser.popup_handler import setup_dialog_handler
 from browser.popup_handler_utility import close_all_popups_event
@@ -18,7 +19,9 @@ def click_sales_analysis_tab(page) -> bool:
     selector = "div.nexatextitem:has-text('매출분석')"
     try:
         element = page.wait_for_selector(selector, timeout=5000)
+        wait(page)
         element.click()
+        wait(page)
         log("'매출분석' 탭 클릭 성공")
         return True
     except Exception as e:
@@ -50,7 +53,9 @@ def find_and_click(page, text: str) -> bool:
     for target in search_targets:
         locator = target.locator(f"text={text}")
         if locator.count() > 0:
+            wait(page)
             locator.first.click()
+            wait(page)
             return True
     return False
 
@@ -58,12 +63,16 @@ def find_and_click(page, text: str) -> bool:
 def navigate_sales_ratio(page):
     if not popups_handled():
         raise RuntimeError("팝업 처리가 완료되지 않아 메뉴 이동을 중단합니다")
+    wait(page)
     if not click_sales_analysis_tab(page):
         raise RuntimeError("Cannot find '매출분석' menu")
+    wait(page)
     expect(page.locator("text=중분류별 매출 구성비")).to_be_visible(timeout=5000)
     if not find_and_click(page, "중분류별 매출 구성비"):
         raise RuntimeError("Cannot find '중분류별 매출 구성비' submenu")
+    wait(page)
     page.wait_for_load_state("networkidle")
+    wait(page)
 
 
 def run():
@@ -86,22 +95,31 @@ def run():
         inject_init_cleanup_script(page)
         setup_dialog_handler(page)
         try:
+            wait(page)
             page.goto(url)
+            wait(page)
 
             page.locator(st["id"]).click()
+            wait(page)
             page.keyboard.type(user_id)
+            wait(page)
             page.locator(st["password"]).click()
+            wait(page)
             page.keyboard.type(user_pw)
+            wait(page)
             page.locator(st["login_button"]).click()
+            wait(page)
 
             wait_after_login = cfg.get("wait_after_login", 0)
             if wait_after_login:
                 page.wait_for_timeout(wait_after_login * 1000)
+            wait(page)
 
             if not popups_handled():
                 if not close_all_popups_event(page):
                     log("❗ 팝업을 모두 닫지 못해 작업을 중단합니다")
                     return
+            wait(page)
 
             navigate_sales_ratio(page)
             log("메뉴 이동 완료")

--- a/utils/common.py
+++ b/utils/common.py
@@ -9,6 +9,13 @@ import pyautogui
 import pygetwindow as gw
 from playwright.sync_api import Page
 
+DEFAULT_WAIT_MS = 1000
+
+
+def wait(page: Page, ms: int = DEFAULT_WAIT_MS) -> None:
+    """Convenience wrapper for ``page.wait_for_timeout``."""
+    page.wait_for_timeout(ms)
+
 # 팝업 처리 상태를 추적하기 위한 전역 변수
 EXPECTED_POPUPS = 2
 _closed_popups = 0


### PR DESCRIPTION
## Summary
- add `wait()` helper in utils with default 1s delay
- apply wait calls around login interactions
- enforce waits inside menu navigation and extraction routines
- update popup handler default wait interval
- ensure sales analysis workflow uses waits between steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a4291f04483208a3a3ce2db01284f