### PR TITLE
Implement wait strategy after login and popup close

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -89,6 +89,8 @@ def perform_login(page: Page, structure: dict) -> bool:
             log("✅ 메뉴 로딩 완료")
 
         log("[로그인] 로그인 성공 판단 완료")
+        log("✅ 로그인 성공 → 안정화 대기")
+        page.wait_for_timeout(3000)
         setup_dialog_handler(page)
         return True
 

--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -135,6 +135,8 @@ def close_detected_popups(page: Page, loops: int = 2, wait_ms: int = 500) -> boo
                             btn.click(timeout=0)
                         if pop.value:
                             pop.value.close()
+                        frame.wait_for_timeout(3000)
+                        utils.log("⏱️ 팝업 닫기 후 3초간 안정화 대기")
                         found = True
                         closed_any = True
                     except Exception:

--- a/popup_text_handler.py
+++ b/popup_text_handler.py
@@ -38,6 +38,8 @@ def handle_popup_by_text(page: Page) -> bool:
             log(f"📌 팝업 탐지됨: '{popup_title}' → 규칙 적용")
             try:
                 rule["action"](page, rule["selector"])
+                page.wait_for_timeout(3000)
+                log("⏱️ 팝업 닫기 후 3초간 안정화 대기")
                 return True
             except Exception as e:
                 log(f"❌ 팝업 닫기 실패: {e}")


### PR DESCRIPTION
## Summary
- add a 3-second stabilization wait after login success
- wait 3 seconds after closing popups to avoid rendering issues

## Testing
- `python -m compileall -q auth.py browser popup_text_handler.py utils`

------
https://chatgpt.com/codex/tasks/task_e_685a440797388320b81a9ee60ece0551