### PR TITLE
Ensure stabilization wait after popup or dialog

### DIFF
--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -73,6 +73,7 @@ def register_dialog_handler(page: Page) -> None:
             _last_dialog_message = msg
             utils.log(f"🟡 다이얼로그 감지됨: '{msg}'")
             dialog.accept()
+            time.sleep(2)
         except Exception as e:  # pragma: no cover - logging only
             utils.log(f"❌ 다이얼로그 처리 실패 또는 중복 처리 시도됨: {e}")
 
@@ -118,6 +119,7 @@ def setup_dialog_handler(page: Page, auto_accept: bool = True) -> None:
                     dialog.dismiss()
                 except Exception as e:
                     utils.log(f"dialog.dismiss 오류: {e}")
+            time.sleep(2)
             utils.log(f"자동 다이얼로그 처리: {msg}")
         except Exception as e:
             utils.log(f"다이얼로그 처리 오류: {e}")

--- a/browser/popup_handler_utility.py
+++ b/browser/popup_handler_utility.py
@@ -44,6 +44,7 @@ def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 1000) -> b
                         btn.click(timeout=0)
                     if pop.value:
                         pop.value.close()
+                    page.wait_for_timeout(2000)
                     found = True
                     closed_any = True
                 except TimeoutError:
@@ -71,6 +72,7 @@ def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 1000) -> b
                 if btn.is_visible():
                     try:
                         btn.click(timeout=0)
+                        page.wait_for_timeout(2000)
                         found = True
                         break
                     except Exception:
@@ -140,6 +142,7 @@ def close_layer_popup(
                         btn.first.click()
                     if pop_info.value:
                         pop_info.value.close()
+                    page.wait_for_timeout(2000)
                     clicked = True
                     break
             except Exception as e:
@@ -150,6 +153,7 @@ def close_layer_popup(
         try:
             layer.first.wait_for(state="hidden", timeout=timeout)
             utils.log("✅ 레이어 팝업 닫힘")
+            page.wait_for_timeout(2000)
             return True
         except TimeoutError:
             utils.log("❌ 레이어 팝업 닫기 시간 초과")

--- a/utils/common.py
+++ b/utils/common.py
@@ -162,6 +162,7 @@ def setup_dialog_handler(page, auto_accept: bool = True) -> None:
                     dialog.dismiss()
                 except Exception as e:
                     print(f"dialog.dismiss 오류: {e}")
+            time.sleep(2)
             print(f"자동 다이얼로그 처리: {dialog.message}")
         except Exception as e:
             print(f"다이얼로그 처리 오류: {e}")
@@ -330,7 +331,7 @@ def close_popups(
                         continue
                     try:
                         btn.click(timeout=0)
-                        frame.wait_for_timeout(300)
+                        frame.wait_for_timeout(2000)
                         closed += 1
                         loop_closed += 1
                     except Exception as e:  # pragma: no cover - logging only


### PR DESCRIPTION
## Summary
- add 2 second wait after automatically accepting or dismissing dialogs
- wait after closing popups and layer dialogs
- extend popup closing wait time for reliability

## Testing
- `python -m py_compile browser/popup_handler_utility.py browser/popup_handler.py utils/common.py`

------
https://chatgpt.com/codex/tasks/task_e_685a5014c47c83209e99fc3ba9e6ab6b