### PR TITLE
Enhance popup handling robustness

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -7,7 +7,7 @@ from browser.popup_handler_utility import (
     close_all_popups,
     setup_dialog_handler,
 )
-from browser.popup_handler import register_dialog_handler
+from browser.popup_handler import register_dialog_handler, add_safe_accept_once
 
 load_dotenv()
 
@@ -55,7 +55,7 @@ def perform_login(page: Page, structure: dict) -> bool:
         login_btn = page.locator(structure["login_button"])
         log("[로그인] 로그인 버튼 클릭")
         wait(page)
-        register_dialog_handler(page)
+        add_safe_accept_once(page)
         page.wait_for_timeout(2000)
         login_btn.click()
         page.wait_for_timeout(2000)

--- a/browser/popup_handler_utility.py
+++ b/browser/popup_handler_utility.py
@@ -1,7 +1,11 @@
 import datetime
 from playwright.sync_api import Page, TimeoutError
 import utils
-from .popup_handler import setup_dialog_handler as _setup_dialog_handler, register_dialog_handler
+from .popup_handler import (
+    setup_dialog_handler as _setup_dialog_handler,
+    register_dialog_handler,
+    add_safe_accept_once,
+)
 
 from popup_text_handler import handle_popup_by_text
 
@@ -39,7 +43,7 @@ def close_all_popups_event(page: Page, loops: int = 2, wait_ms: int = 1000) -> b
                 if not btn.is_visible():
                     continue
                 try:
-                    page.once("dialog", lambda d: d.accept())
+                    add_safe_accept_once(page)
                     with page.expect_popup(timeout=500) as pop:
                         btn.click(timeout=0)
                     if pop.value:
@@ -137,7 +141,7 @@ def close_layer_popup(
             try:
                 btn = page.locator(sel)
                 if btn.count() > 0 and btn.first.is_visible():
-                    page.once("dialog", lambda d: d.accept())
+                    add_safe_accept_once(page)
                     with page.expect_popup(timeout=500) as pop_info:
                         btn.first.click()
                     if pop_info.value:

--- a/popup_text_handler.py
+++ b/popup_text_handler.py
@@ -1,5 +1,6 @@
 from playwright.sync_api import Page
 from utils import log
+from browser.popup_handler import add_safe_accept_once
 
 POPUP_RULES = [
     {
@@ -10,7 +11,7 @@ POPUP_RULES = [
     {
         "contains": ["비밀번호를 입력"],
         "selector": "dialog",
-        "action": lambda page, sel: page.once("dialog", lambda d: d.accept()),
+        "action": lambda page, sel: add_safe_accept_once(page),
     },
     {
         "contains": ["세션이 만료"],
@@ -23,11 +24,27 @@ EXCLUDE_TEXTS = ["Copyright", "BGF Retail"]
 
 
 def handle_popup_by_text(page: Page) -> bool:
+    target = page
     try:
-        popup_title = page.locator("div[id$='Static00:text']").inner_text(timeout=1000)
+        loc = page.locator("div[id$='Static00:text']")
+        if loc.count() > 0:
+            popup_title = loc.first.inner_text(timeout=1000)
+        else:
+            raise Exception("not found")
     except Exception:
-        log("팝업 제목 탐지 실패")
-        return False
+        log("팝업 제목 탐지 실패 → 프레임 탐색")
+        popup_title = None
+        for frame in page.frames:
+            try:
+                loc = frame.locator("div[id$='Static00:text']")
+                if loc.count() > 0:
+                    popup_title = loc.first.inner_text(timeout=1000)
+                    target = frame
+                    break
+            except Exception:
+                continue
+        if not popup_title:
+            return False
 
     if any(ex in popup_title for ex in EXCLUDE_TEXTS):
         log("⏩ 제외 팝업으로 판단 - 무시")
@@ -37,8 +54,8 @@ def handle_popup_by_text(page: Page) -> bool:
         if any(keyword in popup_title for keyword in rule["contains"]):
             log(f"📌 팝업 탐지됨: '{popup_title}' → 규칙 적용")
             try:
-                rule["action"](page, rule["selector"])
-                page.wait_for_timeout(3000)
+                rule["action"](target, rule["selector"])
+                target.wait_for_timeout(3000)
                 log("⏱️ 팝업 닫기 후 3초간 안정화 대기")
                 return True
             except Exception as e:

--- a/utils/common.py
+++ b/utils/common.py
@@ -156,7 +156,10 @@ def setup_dialog_handler(page, auto_accept: bool = True) -> None:
                 log("❌ '추가 대화 차단' 다이얼로그 감지")
                 raise RuntimeError("Dialog blocked by browser")
             if auto_accept:
-                dialog.accept()
+                try:
+                    dialog.accept()
+                except Exception as e:
+                    log(f"dialog.accept 오류: {e}")
             else:
                 try:
                     dialog.dismiss()


### PR DESCRIPTION
## Summary
- ensure login dialog handling is done with `add_safe_accept_once`
- export new `safe_accept` and `add_safe_accept_once` helpers
- use safe accept in popup utilities and text handler
- search frames when detecting popup titles
- wrap all `dialog.accept` calls in try/except

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a58ced2e083209881b557fdb187e9