### PR TITLE
Simplify login script

### DIFF
--- a/run/main.py
+++ b/run/main.py
@@ -1,22 +1,14 @@
-"""Simple login script."""
-
-import os
 import json
-import sys
-
+import os
+from pathlib import Path
 from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright
 
-PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, PROJECT_ROOT)
-
-from auth import perform_login
-from utils import inject_init_cleanup_script, log, wait
-
 load_dotenv()
 
-STRUCTURE_PATH = os.path.join(PROJECT_ROOT, "config", "page_structure.json")
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+STRUCTURE_PATH = PROJECT_ROOT / "config" / "page_structure.json"
+URL = "https://store.bgfretail.com/websrc/deploy/index.html"
 
 
 def load_structure() -> dict:
@@ -26,13 +18,16 @@ def load_structure() -> dict:
 
 def main() -> None:
     structure = load_structure()
+    user_id = os.getenv("LOGIN_ID")
+    user_pw = os.getenv("LOGIN_PW")
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
         page = browser.new_page()
-        inject_init_cleanup_script(page)
-        success = perform_login(page, structure)
-        wait(page)
-        log("로그인 성공" if success else "로그인 실패", stage="결과")
+        page.goto(URL)
+        page.fill(structure["id"], user_id)
+        page.fill(structure["password"], user_pw)
+        page.click(structure["login_button"])
+        page.wait_for_timeout(5000)
         browser.close()
 
 


### PR DESCRIPTION
## Summary
- update main login script to only open the page, log in, wait 5 seconds, and close the browser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a605bfff08320ad58b6ba533986c2