### PR TITLE
Implement login flow with popup handling

### DIFF
--- a/run/main.py
+++ b/run/main.py
@@ -1,33 +1,53 @@
-import json
 import os
-from pathlib import Path
+import datetime
 from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright
 
+from browser.popup_handler_utility import close_all_popups_event
+from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
+from utils import popups_handled
+
 load_dotenv()
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-STRUCTURE_PATH = PROJECT_ROOT / "config" / "page_structure.json"
-URL = "https://store.bgfretail.com/websrc/deploy/index.html"
+ID = os.getenv("LOGIN_ID")
+PW = os.getenv("LOGIN_PW")
 
 
-def load_structure() -> dict:
-    with open(STRUCTURE_PATH, "r", encoding="utf-8") as f:
-        return json.load(f)
+def close_popups(page) -> bool:
+    """Attempt to close all popups using multiple search passes."""
+    if popups_handled():
+        return True
+    success = close_all_popups_event(page, loops=3, wait_ms=1000)
+    return success and popups_handled()
 
 
-def main() -> None:
-    structure = load_structure()
-    user_id = os.getenv("LOGIN_ID")
-    user_pw = os.getenv("LOGIN_PW")
+def main():
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
         page = browser.new_page()
-        page.goto(URL)
-        page.fill(structure["id"], user_id)
-        page.fill(structure["password"], user_pw)
-        page.click(structure["login_button"])
+        page.goto("https://store.bgfretail.com/websrc/deploy/index.html")
+
+        # 아이디 입력
+        page.fill("#txtUserID", ID)
+        page.wait_for_timeout(1000)
+
+        # 비밀번호 입력
+        page.fill("#txtPassWord", PW)
+        page.wait_for_timeout(1000)
+
+        # 로그인 버튼 클릭
+        page.click("#btnLogin")
+
+        # 로그인 결과 확인을 위해 5초 대기
         page.wait_for_timeout(5000)
+
+        if not close_popups(page):
+            browser.close()
+            return
+
+        if datetime.datetime.today().weekday() == 0:
+            navigate_sales_ratio(page)
+
         browser.close()
 
 


### PR DESCRIPTION
## Summary
- add structured login flow with explicit delays
- close all detected popups before continuing
- conditionally navigate to sales ratio page every Monday

## Testing
- `python -m py_compile run/main.py sales_analysis/navigate_sales_ratio.py`

------
https://chatgpt.com/codex/tasks/task_e_685a63730b948320a3fc700936cc14f2