### PR TITLE
Simplify main login script

### DIFF
--- a/run/main.py
+++ b/run/main.py
@@ -3,9 +3,7 @@ import datetime
 from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright
 
-from browser.popup_handler_utility import close_all_popups_event
 from sales_analysis.navigate_sales_ratio import navigate_sales_ratio
-from utils import popups_handled
 
 load_dotenv()
 
@@ -13,12 +11,55 @@ ID = os.getenv("LOGIN_ID")
 PW = os.getenv("LOGIN_PW")
 
 
-def close_popups(page) -> bool:
-    """Attempt to close all popups using multiple search passes."""
-    if popups_handled():
+POPUPS_CLOSED = False
+
+
+def close_popups(page, loops: int = 2) -> bool:
+    """Close visible popups by searching common close buttons."""
+    global POPUPS_CLOSED
+    if POPUPS_CLOSED:
         return True
-    success = close_all_popups_event(page, loops=3, wait_ms=1000)
-    return success and popups_handled()
+
+    selectors = [
+        "text=닫기",
+        "button:has-text('닫기')",
+        "a:has-text('닫기')",
+        "[class*='close']",
+        "[id*='close']",
+    ]
+
+    for _ in range(max(2, loops)):
+        found = False
+        for sel in selectors:
+            try:
+                locs = page.locator(sel)
+                for i in range(locs.count()):
+                    btn = locs.nth(i)
+                    if btn.is_visible():
+                        try:
+                            btn.click(timeout=0)
+                            page.wait_for_timeout(500)
+                            found = True
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+        if not found:
+            break
+        page.wait_for_timeout(1000)
+
+    for sel in selectors:
+        try:
+            locs = page.locator(sel)
+            for i in range(locs.count()):
+                if locs.nth(i).is_visible():
+                    POPUPS_CLOSED = False
+                    return False
+        except Exception:
+            continue
+
+    POPUPS_CLOSED = True
+    return True
 
 
 def main():


### PR DESCRIPTION
## Summary
- rewrite `run/main.py` to remove external dependencies
- add custom popup closing routine
- call sales analysis navigation only on Mondays

## Testing
- `python -m py_compile run/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685a6614bfd883208e9e52a8943390ab