### PR TITLE
Remove utils usage from main

### DIFF
--- a/run/main.py
+++ b/run/main.py
@@ -1,7 +1,6 @@
 import datetime
 from playwright.sync_api import sync_playwright
 
-import utils
 from login.login_handler import perform_login
 
 POPUPS_CLOSED = False
@@ -11,7 +10,6 @@ def close_popups(page, loops: int = 2) -> bool:
     """Close visible popups by searching common close buttons."""
     global POPUPS_CLOSED
     if POPUPS_CLOSED:
-        utils.popup_handled = True
         return True
 
     selectors = [
@@ -48,13 +46,11 @@ def close_popups(page, loops: int = 2) -> bool:
             for i in range(locs.count()):
                 if locs.nth(i).is_visible():
                     POPUPS_CLOSED = False
-                    utils.popup_handled = False
                     return False
         except Exception:
             continue
 
     POPUPS_CLOSED = True
-    utils.popup_handled = True
     return True
 
 


### PR DESCRIPTION
## Summary
- strip out utils import from `run/main.py`
- handle popup tracking within `run.main` without utils

## Testing
- `python -m py_compile run/main.py login/login_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_685a6cf56074832089b1e777c5e9de4c