### PR TITLE
Fix import for login handler

### DIFF
--- a/run/main.py
+++ b/run/main.py
@@ -1,5 +1,12 @@
 import datetime
+import sys
+from pathlib import Path
 from playwright.sync_api import sync_playwright
+
+# Ensure the project root is in the module search path so "login" package is found
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from login.login_handler import perform_login
 


### PR DESCRIPTION
## Summary
- add project root to `sys.path` so running `python run/main.py` works

## Testing
- `pytest -q`
- `python run/main.py` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_685a6dd022648320a7eddf6fa563dd4c