### PR TITLE
Ensure login success before popup handling

### DIFF
--- a/login/login_handler.py
+++ b/login/login_handler.py
@@ -1,21 +1,47 @@
 import os
 from playwright.sync_api import Page
 from dotenv import load_dotenv
+from browser.popup_handler import is_logged_in
+from utils import log
 
 load_dotenv()
 ID = os.getenv("LOGIN_ID")
 PW = os.getenv("LOGIN_PW")
 
 
-def perform_login(page: Page):
+def perform_login(page: Page) -> bool:
+    """Login using credentials from ``.env``.
+
+    Returns
+    -------
+    bool
+        ``True`` on successful login, ``False`` otherwise.
+    """
     page.goto("https://store.bgfretail.com/websrc/deploy/index.html")
 
-    page.wait_for_selector("#mainframe\\.HFrameSet00\\.LoginFrame\\.form\\.div_login\\.form\\.edt_id\\:input", timeout=10000)
-    page.fill("#mainframe\\.HFrameSet00\\.LoginFrame\\.form\\.div_login\\.form\\.edt_id\\:input", ID)
+    page.wait_for_selector(
+        "#mainframe\\.HFrameSet00\\.LoginFrame\\.form\\.div_login\\.form\\.edt_id\\:input",
+        timeout=10000,
+    )
+    page.fill(
+        "#mainframe\\.HFrameSet00\\.LoginFrame\\.form\\.div_login\\.form\\.edt_id\\:input",
+        ID,
+    )
     page.wait_for_timeout(1000)
 
-    page.fill("#mainframe\\.HFrameSet00\\.LoginFrame\\.form\\.div_login\\.form\\.edt_pw\\:input", PW)
+    page.fill(
+        "#mainframe\\.HFrameSet00\\.LoginFrame\\.form\\.div_login\\.form\\.edt_pw\\:input",
+        PW,
+    )
     page.wait_for_timeout(1000)
 
     page.keyboard.press("Enter")
-    page.wait_for_timeout(5000)
+    page.wait_for_load_state("networkidle")
+    page.wait_for_timeout(2000)
+
+    if is_logged_in(page):
+        log("✅ 로그인 성공")
+        return True
+    else:
+        log("❌ 로그인 실패")
+        return False

--- a/run/main.py
+++ b/run/main.py
@@ -17,7 +17,10 @@ def main():
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
         page = browser.new_page()
-        perform_login(page)
+        if not perform_login(page):
+            browser.close()
+            return
+
         if not process_popups_once(page):
             browser.close()
             return


### PR DESCRIPTION
## Summary
- verify login succeeded using `is_logged_in` and log the result
- abort main routine if login fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685a8cc04f608320a534f9a6e25fc4b4