### PR TITLE
Fix popup handler import

### DIFF
--- a/login/login_handler.py
+++ b/login/login_handler.py
@@ -1,7 +1,7 @@
 import os
 from playwright.sync_api import Page
 from dotenv import load_dotenv
-from browser.popup_handler import is_logged_in
+from popup_handler import is_logged_in
 from utils import log
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- correct popup handler import path in login handler

## Testing
- `python -m py_compile login/login_handler.py sales_analysis/navigate_sales_ratio.py browser/popup_handler.py browser/popup_handler_utility.py utils/common.py run/codex_runner.py auth.py order.py`

------
https://chatgpt.com/codex/tasks/task_e_685a8eced8a4832091a026bb9ea79b62