### PR TITLE
Fix imports and ensure module path setup

### DIFF
--- a/login/login_handler.py
+++ b/login/login_handler.py
@@ -2,7 +2,7 @@ import os
 import sys
 from playwright.sync_api import Page
 from dotenv import load_dotenv
-from popup_handler import is_logged_in
+from browser.popup_handler import is_logged_in
 from common import log
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/run/main.py
+++ b/run/main.py
@@ -1,7 +1,9 @@
 import datetime
-import sys
 from pathlib import Path
 from playwright.sync_api import sync_playwright
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 # Ensure the project root is in the module search path so "login" package is found
 ROOT_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary
- fix popup_handler import path for login handler
- insert sys.path fix in `run/main.py`

## Testing
- `python -m compileall -q login/login_handler.py run/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685a956b9730832080fcf4c8d9eab9d9