### PR TITLE
Fix utils import path

### DIFF
--- a/browser/popup_handler.py
+++ b/browser/popup_handler.py
@@ -6,7 +6,7 @@ from playwright.sync_api import Page
 import sys
 import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-import common as utils
+from utils import common as utils
 from popup_text_handler import handle_popup_by_text
 from . import popup_utils
 


### PR DESCRIPTION
## Summary
- fix PYTHONPATH handling in `popup_handler`

## Testing
- `pytest -q`
- `python -m py_compile browser/popup_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_685a9a33d6308320b7fb750c492d70ff